### PR TITLE
Docs - fix examples for components

### DIFF
--- a/docs/src/content/docs/components/pin-input.mdx
+++ b/docs/src/content/docs/components/pin-input.mdx
@@ -34,7 +34,7 @@ Things I want:
 	<TabItem label="Builder">
 ```svelte
 <script lang="ts">
-	import { PinInput } from "melt";
+	import { PinInput } from "melt/builders";
 
 	const pinInput = new PinInput();
 </script>

--- a/docs/src/content/docs/components/popover.mdx
+++ b/docs/src/content/docs/components/popover.mdx
@@ -34,7 +34,7 @@ Things I want:
 	<TabItem label="Builder">
 ```svelte
 <script lang="ts">
-	import { Popover } from "melt";
+	import { Popover } from "melt/builders";
 
 	const popover = new Popover();
 </script>
@@ -53,7 +53,7 @@ Things I want:
 </script>
 
 <Popover>
-	{#snippet children(pinInput)}
+	{#snippet children(popover)}
 		<button {...popover.trigger}>
 			Click me to open the Popover
 		</button>

--- a/docs/src/content/docs/components/toggle.mdx
+++ b/docs/src/content/docs/components/toggle.mdx
@@ -30,7 +30,7 @@ Things I want:
 	<TabItem label="Builder">
 ```svelte
 <script lang="ts">
-	import { Toggle } from "melt";
+	import { Toggle } from "melt/builders";
 
 	const toggle = new Toggle();
 </script>

--- a/docs/src/content/docs/components/tree.mdx
+++ b/docs/src/content/docs/components/tree.mdx
@@ -34,7 +34,7 @@ Things I want:
 	<TabItem label="Builder">
 ```svelte
 <script lang="ts">
-	import { Tree } from "melt";
+	import { Tree } from "melt/builders";
 
 	const tree = new Tree();
 </script>


### PR DESCRIPTION
Minor change to components/builders [pin-input, popover, toggle, tree] to be consistent with other examples [installation, tabs, slider, tree]. Additionally, a fix for the Popover component example where the name referred to Pin Input.