### PR TITLE
Fix for #10

### DIFF
--- a/packages/melt/src/lib/builders/Popover.svelte.ts
+++ b/packages/melt/src/lib/builders/Popover.svelte.ts
@@ -15,6 +15,7 @@ import {
 	type ComputePositionConfig,
 	type Placement,
 } from "@floating-ui/dom";
+import type { Middleware } from "@floating-ui/core";
 import { useEventListener } from "runed";
 import type { HTMLAttributes } from "svelte/elements";
 


### PR DESCRIPTION
Adding import type from @floating-ui/core to eliminate the problem that blocks the generating of d.ts file for Popover.svelte.ts during the run of svelte-package