### PR TITLE
Feat: Radio Group

### DIFF
--- a/.changeset/spotty-insects-exist.md
+++ b/.changeset/spotty-insects-exist.md
@@ -1,0 +1,5 @@
+---
+"melt": minor
+---
+
+Add Radio Group

--- a/docs/src/api.json
+++ b/docs/src/api.json
@@ -396,6 +396,123 @@
     "methods": [],
     "properties": []
   },
+  "RadioGroup": {
+    "constructorProps": [
+      {
+        "name": "disabled",
+        "type": "MaybeGetter<boolean | undefined>",
+        "description": "If `true`, prevents the user from interacting with the group.",
+        "defaultValue": "false",
+        "optional": true
+      },
+      {
+        "name": "required",
+        "type": "MaybeGetter<boolean | undefined>",
+        "description": "If `true`, indicates that the user must select a radio button before\nthe owning form can be submitted.",
+        "defaultValue": "false",
+        "optional": true
+      },
+      {
+        "name": "loop",
+        "type": "MaybeGetter<boolean | undefined>",
+        "description": "If the the button selection should loop when navigating with the arrow keys.",
+        "defaultValue": "true",
+        "optional": true
+      },
+      {
+        "name": "selectWhenFocused",
+        "type": "MaybeGetter<boolean | undefined>",
+        "description": "If `true`, the value will be changed whenever a button is focused.",
+        "defaultValue": "true",
+        "optional": true
+      },
+      {
+        "name": "orientation",
+        "type": "MaybeGetter<\"horizontal\" | \"vertical\" | undefined>",
+        "description": "The orientation of the slider.",
+        "defaultValue": "\"vertical\"",
+        "optional": true
+      },
+      {
+        "name": "name",
+        "type": "MaybeGetter<string | undefined>",
+        "optional": true
+      },
+      {
+        "name": "value",
+        "type": "MaybeGetter<string | undefined>",
+        "description": "The default value for",
+        "optional": true
+      },
+      {
+        "name": "items",
+        "type": "MaybeGetter<string[]>",
+        "description": "Array of all possible values.",
+        "optional": false
+      },
+      {
+        "name": "onValueChange",
+        "type": "((active: string) => void) | undefined",
+        "description": "Called when the radio button is clicked.",
+        "optional": true
+      }
+    ],
+    "methods": [
+      {
+        "name": "select",
+        "type": "(id: string) => void",
+        "description": ""
+      }
+    ],
+    "properties": [
+      {
+        "name": "disabled",
+        "type": "boolean",
+        "description": ""
+      },
+      {
+        "name": "required",
+        "type": "boolean",
+        "description": ""
+      },
+      {
+        "name": "loop",
+        "type": "boolean",
+        "description": ""
+      },
+      {
+        "name": "selectWhenFocused",
+        "type": "boolean",
+        "description": ""
+      },
+      {
+        "name": "orientation",
+        "type": "\"horizontal\" | \"vertical\"",
+        "description": ""
+      },
+      {
+        "name": "value",
+        "type": "string",
+        "description": ""
+      },
+      {
+        "name": "root",
+        "type": "{\n  readonly \"data-melt-radio-group-root\": \"\"\n  readonly role: \"radiogroup\"\n  readonly \"data-orientation\": \"horizontal\" | \"vertical\"\n  readonly \"aria-required\": boolean\n}",
+        "description": ""
+      },
+      {
+        "name": "items",
+        "type": "RadioItem[]",
+        "description": ""
+      },
+      {
+        "name": "hiddenInput",
+        "type": "{\n  readonly \"data-melt-radio-group-hidden-input\": \"\"\n  readonly disabled: boolean\n  readonly required: boolean\n  readonly hidden: true\n  readonly \"aria-hidden\": true\n  readonly tabindex: -1\n  readonly value: string\n  readonly name: string | undefined\n}",
+        "description": ""
+      }
+    ],
+    "propsAlt": "export type RadioGroupProps = {\n  /**\n   * If `true`, prevents the user from interacting with the group.\n   *\n   * @default false\n   */\n  disabled?: MaybeGetter<boolean | undefined>;\n  /**\n   * If `true`, indicates that the user must select a radio button before\n   * the owning form can be submitted.\n   *\n   * @default false\n   */\n  required?: MaybeGetter<boolean | undefined>;\n  /**\n   * If the the button selection should loop when navigating with the arrow keys.\n   *\n   * @default true\n   */\n  loop?: MaybeGetter<boolean | undefined>;\n  /**\n   * If `true`, the value will be changed whenever a button is focused.\n   *\n   * @default true\n   */\n  selectWhenFocused?: MaybeGetter<boolean | undefined>;\n  /**\n   * The orientation of the slider.\n   *\n   * @default \"vertical\"\n   */\n  orientation?: MaybeGetter<\"horizontal\" | \"vertical\" | undefined>;\n  name?: MaybeGetter<string | undefined>;\n  /**\n   * The default value for\n   */\n  value?: MaybeGetter<string | undefined>;\n  /**\n   * Array of all possible values.\n   */\n  items: MaybeGetter<string[]>;\n  /**\n   * Called when the radio button is clicked.\n   */\n  onValueChange?: (active: string) => void;\n};"
+  },
   "Popover": {
     "constructorProps": [
       {

--- a/docs/src/api.json
+++ b/docs/src/api.json
@@ -436,19 +436,15 @@
       {
         "name": "name",
         "type": "MaybeGetter<string | undefined>",
+        "description": "Input name for radio group.",
         "optional": true
       },
       {
         "name": "value",
         "type": "MaybeGetter<string | undefined>",
-        "description": "The default value for",
+        "description": "Default value for radio group.",
+        "defaultValue": "\"\"",
         "optional": true
-      },
-      {
-        "name": "items",
-        "type": "MaybeGetter<string[]>",
-        "description": "Array of all possible values.",
-        "optional": false
       },
       {
         "name": "onValueChange",
@@ -459,8 +455,13 @@
     ],
     "methods": [
       {
+        "name": "getItem",
+        "type": "(item: string) => RadioItem",
+        "description": ""
+      },
+      {
         "name": "select",
-        "type": "(id: string) => void",
+        "type": "(item: string) => void",
         "description": ""
       }
     ],
@@ -497,12 +498,12 @@
       },
       {
         "name": "root",
-        "type": "{\n  readonly \"data-melt-radio-group-root\": \"\"\n  readonly role: \"radiogroup\"\n  readonly \"data-orientation\": \"horizontal\" | \"vertical\"\n  readonly \"aria-required\": boolean\n}",
+        "type": "{\n  readonly \"data-melt-radio-group-root\": \"\"\n  readonly id: string\n  readonly role: \"radiogroup\"\n  readonly \"aria-required\": boolean\n  readonly \"aria-labelledby\": string\n  readonly \"data-orientation\": \"horizontal\" | \"vertical\"\n  readonly \"data-disabled\": true | undefined\n  readonly \"data-value\": string\n}",
         "description": ""
       },
       {
-        "name": "items",
-        "type": "RadioItem[]",
+        "name": "label",
+        "type": "{\n  readonly \"data-melt-radio-group-label\": \"\"\n  readonly id: string\n  readonly for: string\n  readonly onclick: (\n    e: MouseEvent & { currentTarget: EventTarget & HTMLLabelElement },\n  ) => void\n  readonly \"data-orientation\": \"horizontal\" | \"vertical\"\n  readonly \"data-disabled\": true | undefined\n  readonly \"data-value\": string\n}",
         "description": ""
       },
       {
@@ -511,7 +512,7 @@
         "description": ""
       }
     ],
-    "propsAlt": "export type RadioGroupProps = {\n  /**\n   * If `true`, prevents the user from interacting with the group.\n   *\n   * @default false\n   */\n  disabled?: MaybeGetter<boolean | undefined>;\n  /**\n   * If `true`, indicates that the user must select a radio button before\n   * the owning form can be submitted.\n   *\n   * @default false\n   */\n  required?: MaybeGetter<boolean | undefined>;\n  /**\n   * If the the button selection should loop when navigating with the arrow keys.\n   *\n   * @default true\n   */\n  loop?: MaybeGetter<boolean | undefined>;\n  /**\n   * If `true`, the value will be changed whenever a button is focused.\n   *\n   * @default true\n   */\n  selectWhenFocused?: MaybeGetter<boolean | undefined>;\n  /**\n   * The orientation of the slider.\n   *\n   * @default \"vertical\"\n   */\n  orientation?: MaybeGetter<\"horizontal\" | \"vertical\" | undefined>;\n  name?: MaybeGetter<string | undefined>;\n  /**\n   * The default value for\n   */\n  value?: MaybeGetter<string | undefined>;\n  /**\n   * Array of all possible values.\n   */\n  items: MaybeGetter<string[]>;\n  /**\n   * Called when the radio button is clicked.\n   */\n  onValueChange?: (active: string) => void;\n};"
+    "propsAlt": "export type RadioGroupProps = {\n  /**\n   * If `true`, prevents the user from interacting with the group.\n   *\n   * @default false\n   */\n  disabled?: MaybeGetter<boolean | undefined>;\n  /**\n   * If `true`, indicates that the user must select a radio button before\n   * the owning form can be submitted.\n   *\n   * @default false\n   */\n  required?: MaybeGetter<boolean | undefined>;\n  /**\n   * If the the button selection should loop when navigating with the arrow keys.\n   *\n   * @default true\n   */\n  loop?: MaybeGetter<boolean | undefined>;\n  /**\n   * If `true`, the value will be changed whenever a button is focused.\n   *\n   * @default true\n   */\n  selectWhenFocused?: MaybeGetter<boolean | undefined>;\n  /**\n   * The orientation of the slider.\n   *\n   * @default \"vertical\"\n   */\n  orientation?: MaybeGetter<\"horizontal\" | \"vertical\" | undefined>;\n  /**\n   * Input name for radio group.\n   */\n  name?: MaybeGetter<string | undefined>;\n  /**\n   * Default value for radio group.\n   *\n   * @default \"\"\n   */\n  value?: MaybeGetter<string | undefined>;\n  /**\n   * Called when the radio button is clicked.\n   */\n  onValueChange?: (active: string) => void;\n};"
   },
   "Popover": {
     "constructorProps": [

--- a/docs/src/components/preview.svelte
+++ b/docs/src/components/preview.svelte
@@ -55,9 +55,14 @@
 
 	const CTX_KEY = Symbol();
 
+	// A type that marks all readonly values as writable
+	type Writable<T> = {
+		-readonly [P in keyof T]: T[P];
+	};
+
 	export function usePreviewControls<const Schema extends SchemaExtends>(
 		schema: Schema,
-	): Context<Schema>["values"] {
+	): Writable<Context<Schema>["values"]> {
 		const values = $state(
 			objectMap(schema, (key, { defaultValue }) => {
 				return [key, defaultValue];

--- a/docs/src/content/docs/components/radio-group.mdx
+++ b/docs/src/content/docs/components/radio-group.mdx
@@ -1,0 +1,95 @@
+---
+title: Radio Group
+description: A set of checkable buttons — known as radio buttons — where no more than one of the buttons can be checked at a time.
+---
+import ApiTable from "@components/api-table.astro";
+import Preview from "@previews/radio-group.svelte";
+import Features from "@components/features.astro";
+import ThemedCode from "@components/themed-code.astro";
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+{/*
+Things I want:
+- Preview with props DONE
+- Show builder syntax
+- Show component syntax
+- Features
+*/}
+
+<Preview client:load />
+
+## Features
+
+<Features>
+- 🎹 Keyboard navigation
+- 🧠 Smart focus management
+- 🔄 Horizontal and vertical orientation
+- ~🌐 RTL support~ (incoming!)
+</Features>
+
+## Usage
+
+<Tabs>
+	<TabItem label="Builder">
+```svelte
+<script lang="ts">
+    import { RadioGroup } from "melt/builders";
+
+    const group = new RadioGroup();
+</script>
+
+<div {...group.root}>
+    {#each group.items as item}
+        <div>
+            <button {...item.button}>
+                {#if item.checked}
+                    <p>+</p>
+                {:else}
+                    <p>-</p>
+                {/if}
+            </button>
+            <label {...item.label}>
+                {item.item}
+            </label>
+        </div>
+    {/each}
+    <input {...group.hiddenInput} />
+</div>
+```
+	</TabItem>
+
+	<TabItem label="Component">
+```svelte
+<script lang="ts">
+	import { RadioGroup } from "melt/components";
+</script>
+
+<RadioGroup>
+	{#snippet children(group)}
+		<div {...group.root}>
+            {#each group.items as item}
+                <div>
+                    <button {...item.button}>
+                        {#if item.checked}
+                            <p>+</p>
+                        {:else}
+                            <p>-</p>
+                        {/if}
+                    </button>
+                    <label {...item.label}>
+                        {item.item}
+                    </label>
+                </div>
+            {/each}
+            <input {...group.hiddenInput} />
+        </div>
+	{/snippet}
+</RadioGroup>
+```
+	</TabItem>
+</Tabs>
+
+
+## API Reference
+
+<ApiTable entry="RadioGroup" />

--- a/docs/src/previews/radio-group.svelte
+++ b/docs/src/previews/radio-group.svelte
@@ -1,0 +1,66 @@
+<script lang="ts">
+	import Preview, { usePreviewControls } from "@components/preview.svelte";
+	import { scale } from "svelte/transition";
+	import { RadioGroup } from "melt/components";
+
+	const items = ["default", "comfortable", "compact"];
+
+	let controls = usePreviewControls({
+		value: {
+			type: "select",
+			label: "Value",
+			options: items,
+			defaultValue: "default",
+		},
+		disabled: {
+			type: "boolean",
+			label: "Disabled",
+			defaultValue: false,
+		},
+		loop: {
+			type: "boolean",
+			label: "Loop",
+			defaultValue: false,
+		},
+		selectWhenFocused: {
+			type: "boolean",
+			label: "Select when focused",
+			defaultValue: true,
+		},
+		orientation: {
+			type: "select",
+			label: "Orientation",
+			options: ["horizontal", "vertical"],
+			defaultValue: "vertical",
+		},
+	});
+</script>
+
+<Preview>
+	<RadioGroup {items} {...controls} bind:value={controls.value}>
+		{#snippet children(group)}
+			<div
+				class="mx-auto flex w-fit flex-col gap-3 data-[orientation=horizontal]:flex-row"
+				{...group.root}
+			>
+				{#each group.items as item}
+					<div class="flex items-center gap-3">
+						<button
+							class="grid h-6 w-6 cursor-default place-items-center
+							rounded-full bg-white shadow-sm hover:bg-gray-100 data-[disabled=true]:bg-gray-400"
+							{...item.button}
+						>
+							{#if item.checked}
+								<div transition:scale={{ duration: 250, opacity: 1 }} class="h-3 w-3 rounded-full bg-gray-500"></div>
+							{/if}
+						</button>
+						<label class="font-medium capitalize leading-none text-gray-100" {...item.label}>
+							{item.item}
+						</label>
+					</div>
+				{/each}
+				<input {...group.hiddenInput} />
+			</div>
+		{/snippet}
+	</RadioGroup>
+</Preview>

--- a/docs/src/previews/radio-group.svelte
+++ b/docs/src/previews/radio-group.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import Preview, { usePreviewControls } from "@components/preview.svelte";
 	import { scale } from "svelte/transition";
-	import { RadioGroup } from "melt/components";
+	import { RadioGroup } from "melt/builders";
+	import { getters } from "melt/builders";
 
 	const items = $state(["default", "comfortable", "compact"]);
 
@@ -34,34 +35,45 @@
 			defaultValue: "vertical",
 		},
 	});
+
+	const group = new RadioGroup({
+		...getters(controls),
+		onValueChange(v) {
+			controls.value = v;
+		},
+	});
 </script>
 
 <Preview>
-	<RadioGroup {...controls} bind:value={controls.value}>
-		{#snippet children(group)}
+	<div
+		class="mx-auto flex w-fit flex-col gap-2 data-[orientation=horizontal]:flex-row"
+		{...group.root}
+	>
+		<!-- svelte-ignore a11y_label_has_associated_control -- https://github.com/sveltejs/svelte/issues/15067 -->
+		<label {...group.label} class="font-semibold text-white">Layout</label>
+		{#each items as i}
+			{@const item = group.getItem(i)}
 			<div
-				class="mx-auto flex w-fit flex-col gap-3 data-[orientation=horizontal]:flex-row"
-				{...group.root}
+				class="ring-accent-500 -ml-1 flex items-center gap-3 rounded p-1 outline-none focus-visible:ring"
+				{...item.attrs}
 			>
-				{#each items as item}
-					{@const itemData = group.getItem(item)}
-					<div class="flex items-center gap-3">
-						<button
-							class="grid h-6 w-6 cursor-default place-items-center
+				<div
+					class="grid h-6 w-6 cursor-default place-items-center
 							rounded-full bg-white shadow-sm hover:bg-gray-100 data-[disabled=true]:bg-gray-400"
-							{...itemData.button}
-						>
-							{#if itemData.checked}
-								<div transition:scale={{ duration: 250, opacity: 1 }} class="h-3 w-3 rounded-full bg-gray-500"></div>
-							{/if}
-						</button>
-						<label class="font-medium capitalize leading-none text-gray-100" {...itemData.label}>
-							{item}
-						</label>
-					</div>
-				{/each}
-				<input {...group.hiddenInput} />
+				>
+					{#if item.checked}
+						<div
+							transition:scale={{ duration: 150, opacity: 1 }}
+							class="bg-accent-500 h-3 w-3 rounded-full"
+						></div>
+					{/if}
+				</div>
+
+				<span class="font-medium capitalize leading-none text-gray-100">
+					{i}
+				</span>
 			</div>
-		{/snippet}
-	</RadioGroup>
+		{/each}
+		<input {...group.hiddenInput} />
+	</div>
 </Preview>

--- a/docs/src/previews/radio-group.svelte
+++ b/docs/src/previews/radio-group.svelte
@@ -37,25 +37,26 @@
 </script>
 
 <Preview>
-	<RadioGroup {items} {...controls} bind:value={controls.value}>
+	<RadioGroup {...controls} bind:value={controls.value}>
 		{#snippet children(group)}
 			<div
 				class="mx-auto flex w-fit flex-col gap-3 data-[orientation=horizontal]:flex-row"
 				{...group.root}
 			>
-				{#each group.items as item}
+				{#each items as item}
+					{@const itemData = group.getItem(item)}
 					<div class="flex items-center gap-3">
 						<button
 							class="grid h-6 w-6 cursor-default place-items-center
 							rounded-full bg-white shadow-sm hover:bg-gray-100 data-[disabled=true]:bg-gray-400"
-							{...item.button}
+							{...itemData.button}
 						>
-							{#if item.checked}
+							{#if itemData.checked}
 								<div transition:scale={{ duration: 250, opacity: 1 }} class="h-3 w-3 rounded-full bg-gray-500"></div>
 							{/if}
 						</button>
-						<label class="font-medium capitalize leading-none text-gray-100" {...item.label}>
-							{item.item}
+						<label class="font-medium capitalize leading-none text-gray-100" {...itemData.label}>
+							{item}
 						</label>
 					</div>
 				{/each}

--- a/docs/src/previews/radio-group.svelte
+++ b/docs/src/previews/radio-group.svelte
@@ -3,7 +3,7 @@
 	import { scale } from "svelte/transition";
 	import { RadioGroup } from "melt/components";
 
-	const items = ["default", "comfortable", "compact"];
+	const items = $state(["default", "comfortable", "compact"]);
 
 	let controls = usePreviewControls({
 		value: {

--- a/packages/melt/src/lib/builders/RadioGroup.svelte.ts
+++ b/packages/melt/src/lib/builders/RadioGroup.svelte.ts
@@ -46,15 +46,16 @@ export type RadioGroupProps = {
 	 * @default "vertical"
 	 */
 	orientation?: MaybeGetter<"horizontal" | "vertical" | undefined>;
+	/**
+	 * Input name for radio group.
+	 */
 	name?: MaybeGetter<string | undefined>;
 	/**
-	 * The default value for
+	 * Default value for radio group.
+	 * 
+	 * @default ""
 	 */
 	value?: MaybeGetter<string | undefined>;
-	/**
-	 * Array of all possible values.
-	 */
-	items: MaybeGetter<string[]>;
 	/**
 	 * Called when the radio button is clicked.
 	 */
@@ -78,7 +79,7 @@ export class RadioGroup {
 		this.#value = new Synced({
 			value: props.value,
 			onChange: props.onValueChange,
-			defaultValue: extract(props.items)[0],
+			defaultValue: "",
 		});
 	}
 
@@ -99,8 +100,8 @@ export class RadioGroup {
 		} as const satisfies HTMLAttributes<HTMLElement>;
 	}
 
-	get items() {
-		return extract(this.#props.items).map((item) => new RadioItem({ group: this, item }));
+	getItem(item: string) {
+		return new RadioItem({ group: this, item });
 	}
 
 	get hiddenInput() {
@@ -116,10 +117,8 @@ export class RadioGroup {
 		} as const satisfies HTMLInputAttributes;
 	}
 
-	select(id: string) {
-		if (extract(this.#props.items).includes(id)) {
-			this.value = id;
-		}
+	select(item: string) {
+		this.value = item;
 	}
 }
 

--- a/packages/melt/src/lib/builders/RadioGroup.svelte.ts
+++ b/packages/melt/src/lib/builders/RadioGroup.svelte.ts
@@ -1,0 +1,229 @@
+import { Synced } from "$lib/Synced.svelte";
+import type { MaybeGetter } from "$lib/types";
+import { dataAttr, disabledAttr } from "$lib/utils/attribute";
+import { extract } from "$lib/utils/extract";
+import { createDataIds } from "$lib/utils/identifiers";
+import { isHtmlElement } from "$lib/utils/is";
+import { getDirectionalKeys, kbd } from "$lib/utils/keyboard";
+import type {
+	HTMLAttributes,
+	HTMLButtonAttributes,
+	HTMLInputAttributes,
+	HTMLLabelAttributes,
+} from "svelte/elements";
+
+const identifiers = createDataIds("radio-group", ["root", "item", "label", "hidden-input"]);
+
+export type RadioGroupProps = {
+	/**
+	 * If `true`, prevents the user from interacting with the group.
+	 *
+	 * @default false
+	 */
+	disabled?: MaybeGetter<boolean | undefined>;
+	/**
+	 * If `true`, indicates that the user must select a radio button before
+	 * the owning form can be submitted.
+	 *
+	 * @default false
+	 */
+	required?: MaybeGetter<boolean | undefined>;
+	/**
+	 * If the the button selection should loop when navigating with the arrow keys.
+	 *
+	 * @default true
+	 */
+	loop?: MaybeGetter<boolean | undefined>;
+	/**
+	 * If `true`, the value will be changed whenever a button is focused.
+	 *
+	 * @default true
+	 */
+	selectWhenFocused?: MaybeGetter<boolean | undefined>;
+	/**
+	 * The orientation of the slider.
+	 *
+	 * @default "vertical"
+	 */
+	orientation?: MaybeGetter<"horizontal" | "vertical" | undefined>;
+	name?: MaybeGetter<string | undefined>;
+	/**
+	 * The default value for
+	 */
+	value?: MaybeGetter<string | undefined>;
+	/**
+	 * Array of all possible values.
+	 */
+	items: MaybeGetter<string[]>;
+	/**
+	 * Called when the radio button is clicked.
+	 */
+	onValueChange?: (active: string) => void;
+};
+
+export class RadioGroup {
+	/* Props */
+	#props!: RadioGroupProps;
+	readonly disabled = $derived(extract(this.#props.disabled, false));
+	readonly required = $derived(extract(this.#props.required, false));
+	readonly loop = $derived(extract(this.#props.loop, false));
+	readonly selectWhenFocused = $derived(extract(this.#props.selectWhenFocused, true));
+	readonly orientation = $derived(extract(this.#props.orientation, "vertical"));
+
+	/* State */
+	#value: Synced<string>;
+
+	constructor(props: RadioGroupProps) {
+		this.#props = props;
+		this.#value = new Synced({
+			value: props.value,
+			onChange: props.onValueChange,
+			defaultValue: extract(props.items)[0],
+		});
+	}
+
+	get value() {
+		return this.#value.current;
+	}
+
+	set value(value: string) {
+		this.#value.current = value;
+	}
+
+	get root() {
+		return {
+			[identifiers["root"]]: "",
+			role: "radiogroup",
+			"data-orientation": dataAttr(this.orientation),
+			"aria-required": this.required,
+		} as const satisfies HTMLAttributes<HTMLElement>;
+	}
+
+	get items() {
+		return extract(this.#props.items).map((item) => new RadioItem({ group: this, item }));
+	}
+
+	get hiddenInput() {
+		return {
+			[identifiers["hidden-input"]]: "",
+			disabled: this.disabled,
+			required: this.required,
+			hidden: true,
+			"aria-hidden": true,
+			tabindex: -1,
+			value: this.value,
+			name: extract(this.#props.name),
+		} as const satisfies HTMLInputAttributes;
+	}
+
+	select(id: string) {
+		if (extract(this.#props.items).includes(id)) {
+			this.value = id;
+		}
+	}
+}
+
+type RadioItemProps = {
+	group: RadioGroup;
+	item: string;
+};
+
+class RadioItem {
+	#props!: RadioItemProps;
+
+	#group = $derived(this.#props.group);
+	readonly item = $derived(this.#props.item);
+	readonly checked = $derived(this.#group.value === this.item);
+
+	constructor(props: RadioItemProps) {
+		this.#props = props;
+	}
+
+	get button() {
+		return {
+			id: this.item,
+			[identifiers["item"]]: "",
+			disabled: this.#group.disabled,
+			"data-value": dataAttr(this.item),
+			"data-orientation": dataAttr(this.#group.orientation),
+			"data-disabled": disabledAttr(this.#group.disabled),
+			"data-state": dataAttr(this.checked ? "checked" : "unchecked"),
+			"aria-checked": this.checked,
+			"aria-labelledby": `${this.item}-label`,
+			type: "button",
+			role: "radio",
+			onclick: () => {
+				this.#group.select(this.item);
+			},
+			onkeydown: (e) => {
+				const el = e.currentTarget;
+				const root = el.closest("[data-melt-radio-group-root]");
+				if (!isHtmlElement(root)) return;
+
+				if (e.key === kbd.SPACE) {
+					this.#group.select(el.id);
+					return;
+				}
+
+				const items = Array.from(root.querySelectorAll("[data-melt-radio-group-item]")).filter(
+					(el): el is HTMLElement => isHtmlElement(el) && !el.hasAttribute("data-disabled"),
+				);
+				const currentIdx = items.indexOf(el);
+				const loop = this.#group.loop;
+
+				const style = window.getComputedStyle(el);
+				const dir = style.getPropertyValue("direction") as "ltr" | "rtl";
+				const { nextKey, prevKey } = getDirectionalKeys(dir, this.#group.orientation);
+
+				let itemToFocus: HTMLElement;
+				switch (e.key) {
+					case nextKey: {
+						e.preventDefault();
+						const nextIdx = currentIdx + 1;
+						if (nextIdx >= items.length && loop) {
+							itemToFocus = items[0];
+						} else {
+							itemToFocus = items[nextIdx];
+						}
+						break;
+					}
+					case prevKey: {
+						e.preventDefault();
+						const prevIdx = currentIdx - 1;
+						if (prevIdx < 0 && loop) {
+							itemToFocus = items[items.length - 1];
+						} else {
+							itemToFocus = items[prevIdx];
+						}
+						break;
+					}
+					case kbd.HOME: {
+						e.preventDefault();
+						itemToFocus = items[0];
+						break;
+					}
+					case kbd.END: {
+						e.preventDefault();
+						itemToFocus = items[items.length - 1];
+						break;
+					}
+					default: {
+						return;
+					}
+				}
+
+				if (itemToFocus) {
+					itemToFocus.focus();
+					if (this.#group.selectWhenFocused) this.#group.select(itemToFocus.id);
+				}
+			},
+		} as const satisfies HTMLButtonAttributes;
+	}
+
+	get label() {
+		return {
+			for: this.item,
+			id: `${this.item}-label`,
+		} as const satisfies HTMLLabelAttributes;
+	}
+}

--- a/packages/melt/src/lib/builders/index.ts
+++ b/packages/melt/src/lib/builders/index.ts
@@ -1,5 +1,6 @@
 export * from "./PinInput.svelte";
 export * from "./Popover.svelte";
+export * from "./RadioGroup.svelte";
 export * from "./Tabs.svelte";
 export * from "./Toggle.svelte";
 export * from "./Slider.svelte";

--- a/packages/melt/src/lib/components/RadioGroup.svelte
+++ b/packages/melt/src/lib/components/RadioGroup.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { RadioGroup, type RadioGroupProps } from "../builders/RadioGroup.svelte";
+	import { type Snippet } from "svelte";
+	import type { ComponentProps } from "../types";
+	import { getters } from "$lib/builders";
+
+	type Props = ComponentProps<RadioGroupProps> & {
+		children: Snippet<[RadioGroup]>;
+	};
+
+	let { value = $bindable(undefined), children, ...rest }: Props = $props();
+
+	const group = new RadioGroup({
+		value: () => value,
+		onValueChange: (v) => (value = v),
+		...getters(rest),
+	});
+</script>
+
+{@render children(group)}

--- a/packages/melt/src/lib/components/index.ts
+++ b/packages/melt/src/lib/components/index.ts
@@ -3,3 +3,4 @@ export { default as PinInput } from "./PinInput.svelte";
 export { default as Tabs } from "./Tabs.svelte";
 export { default as Slider } from "./Slider.svelte";
 export { default as Popover } from "./Popover.svelte";
+export { default as RadioGroup } from "./RadioGroup.svelte";

--- a/packages/melt/src/lib/utils/identifiers.ts
+++ b/packages/melt/src/lib/utils/identifiers.ts
@@ -1,8 +1,13 @@
 import { nanoid } from "nanoid";
+import { keys } from "./object";
 
 type DataIds<Name extends string, Parts extends string[]> = {
 	[P in Parts[number]]: `data-melt-${Name}-${P}`;
 };
+
+/**
+ * @deprecated use `createBuilderMeMetaData` instead
+ */
 export function createDataIds<const Name extends string, const Parts extends string[]>(
 	name: Name,
 	parts: Parts,
@@ -25,4 +30,35 @@ export function createIds<const T extends DataIds<string, string[]>>(identifiers
 		return acc;
 		// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	}, {} as any);
+}
+
+export type BuilderMetadata<Name extends string, Parts extends string[]> = {
+	dataAttrs: {
+		[P in Parts[number]]: `data-melt-${Name}-${P}`;
+	};
+	dataSelectors: {
+		[P in Parts[number]]: `[data-melt-${Name}-${P}]`;
+	};
+	createIds: () => {
+		[P in Parts[number]]: string;
+	};
+};
+
+export function createBuilderMetadata<const Name extends string, const Parts extends string[]>(
+	name: Name,
+	parts: Parts,
+): BuilderMetadata<Name, Parts> {
+	// TODO: clean this up
+	const dataAttrs = createDataIds(name, parts);
+	const dataSelectors = keys(dataAttrs).reduce((acc, key) => {
+		acc[key] = `[${dataAttrs[key]}]`;
+		return acc;
+		// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	}, {} as any);
+
+	return {
+		dataAttrs,
+		dataSelectors,
+		createIds: () => createIds(dataAttrs),
+	};
 }

--- a/packages/melt/src/lib/utils/keyboard.ts
+++ b/packages/melt/src/lib/utils/keyboard.ts
@@ -1,0 +1,78 @@
+/**
+ * A constant object that maps commonly used keyboard keys to their corresponding string values.
+ * This object can be used in other parts of the application to handle keyboard input and prevent
+ * hard-coded strings throughout.
+ */
+export const kbd = {
+	ALT: "Alt",
+	ARROW_DOWN: "ArrowDown",
+	ARROW_LEFT: "ArrowLeft",
+	ARROW_RIGHT: "ArrowRight",
+	ARROW_UP: "ArrowUp",
+	BACKSPACE: "Backspace",
+	CAPS_LOCK: "CapsLock",
+	CONTROL: "Control",
+	DELETE: "Delete",
+	END: "End",
+	ENTER: "Enter",
+	ESCAPE: "Escape",
+	F1: "F1",
+	F10: "F10",
+	F11: "F11",
+	F12: "F12",
+	F2: "F2",
+	F3: "F3",
+	F4: "F4",
+	F5: "F5",
+	F6: "F6",
+	F7: "F7",
+	F8: "F8",
+	F9: "F9",
+	HOME: "Home",
+	META: "Meta",
+	PAGE_DOWN: "PageDown",
+	PAGE_UP: "PageUp",
+	SHIFT: "Shift",
+	SPACE: " ",
+	TAB: "Tab",
+	CTRL: "Control",
+	ASTERISK: "*",
+	A: "a",
+	P: "p",
+} as const;
+
+/** Key sets for navigation within lists, such as select, menu, and combobox. */
+export const FIRST_KEYS = [kbd.ARROW_DOWN, kbd.PAGE_UP, kbd.HOME];
+export const LAST_KEYS = [kbd.ARROW_UP, kbd.PAGE_DOWN, kbd.END];
+export const FIRST_LAST_KEYS = [...FIRST_KEYS, ...LAST_KEYS];
+export const SELECTION_KEYS = [kbd.ENTER, kbd.SPACE];
+
+export const getNextKey = (
+	dir: "ltr" | "rtl" = "ltr",
+	orientation: "horizontal" | "vertical" = "horizontal",
+) => {
+	return {
+		horizontal: dir === "rtl" ? kbd.ARROW_LEFT : kbd.ARROW_RIGHT,
+		vertical: kbd.ARROW_DOWN,
+	}[orientation];
+};
+
+export const getPrevKey = (
+	dir: "ltr" | "rtl" = "ltr",
+	orientation: "horizontal" | "vertical" = "horizontal",
+) => {
+	return {
+		horizontal: dir === "rtl" ? kbd.ARROW_RIGHT : kbd.ARROW_LEFT,
+		vertical: kbd.ARROW_UP,
+	}[orientation];
+};
+
+export const getDirectionalKeys = (
+	dir: "ltr" | "rtl" = "ltr",
+	orientation: "horizontal" | "vertical" = "horizontal",
+) => {
+	return {
+		nextKey: getNextKey(dir, orientation),
+		prevKey: getPrevKey(dir, orientation),
+	};
+};


### PR DESCRIPTION
Adds radio group builder and component.

I'm still unsure about passing items to builder directly. If you think items should be separated like in old melt-ui, I'll change it.
 
![image](https://github.com/user-attachments/assets/6e314fd7-ea87-46d0-abcc-046f4a486a14)
