### PR TITLE
Text color tweaks for light mode

### DIFF
--- a/docs/src/previews/avatar.svelte
+++ b/docs/src/previews/avatar.svelte
@@ -57,7 +57,7 @@
 			contenteditable
 			id="gh"
 			class=" w-auto border-b-2 border-neutral-600 bg-transparent px-1 pb-1 text-center text-2xl font-light
-			text-white placeholder-neutral-500 outline-none transition focus:border-neutral-200"
+			placeholder-neutral-500 outline-none transition focus:border-neutral-200 dark:text-white"
 			bind:innerText={username}
 			spellcheck="false"
 		></span>

--- a/docs/src/previews/radio-group.svelte
+++ b/docs/src/previews/radio-group.svelte
@@ -50,7 +50,7 @@
 <Preview>
 	<div class="mx-auto flex w-fit flex-col gap-2" {...group.root}>
 		<!-- svelte-ignore a11y_label_has_associated_control -- https://github.com/sveltejs/svelte/issues/15067 -->
-		<label {...group.label} class="font-semibold text-white">Layout</label>
+		<label {...group.label} class="font-semibold dark:text-white">Layout</label>
 		<div class="flex {isVert ? 'flex-col gap-1' : 'flex-row gap-3'}">
 			{#each items as i}
 				{@const item = group.getItem(i)}
@@ -71,7 +71,7 @@
 						{/if}
 					</div>
 
-					<span class="font-medium capitalize leading-none text-gray-100">
+					<span class="font-medium capitalize leading-none text-gray-900 dark:text-gray-100">
 						{i}
 					</span>
 				</div>


### PR DESCRIPTION
This adds the "dark:" modifier to light-colored text on the avatar and radio button demos so that they're readable when dark mode is off.