### PR TITLE
Fix: incorrect text color when switching themes

### DIFF
--- a/docs/src/previews/avatar.svelte
+++ b/docs/src/previews/avatar.svelte
@@ -57,7 +57,7 @@
 			contenteditable
 			id="gh"
 			class=" w-auto border-b-2 border-neutral-600 bg-transparent px-1 pb-1 text-center text-2xl font-light
-			text-white placeholder-neutral-500 outline-none transition focus:border-neutral-200"
+			dark:text-white placeholder-neutral-500 outline-none transition focus:border-neutral-200"
 			bind:innerText={username}
 			spellcheck="false"
 		></span>

--- a/docs/src/previews/avatar.svelte
+++ b/docs/src/previews/avatar.svelte
@@ -47,17 +47,19 @@
 <Preview>
 	<div class="flex flex-col items-center">
 		<div class="flex w-full items-center justify-center gap-6">
-			<div class="flex size-32 items-center justify-center rounded-full bg-neutral-100">
+			<div
+				class="flex size-32 items-center justify-center rounded-full bg-neutral-300 dark:bg-neutral-100"
+			>
 				<img {...avatar.image} alt="Avatar" class="h-full w-full rounded-[inherit]" />
-				<span {...avatar.fallback} class="text-magnum-700 text-4xl font-medium">{initials}</span>
+				<span {...avatar.fallback} class="text-4xl font-medium text-neutral-700">{initials}</span>
 			</div>
 		</div>
 		<label for="gh" class="mt-4"> GitHub username </label>
 		<span
 			contenteditable
 			id="gh"
-			class=" w-auto border-b-2 border-neutral-600 bg-transparent px-1 pb-1 text-center text-2xl font-light
-			dark:text-white placeholder-neutral-500 outline-none transition focus:border-neutral-200"
+			class="focus:border-accent-200 w-auto border-b-2 border-neutral-600 bg-transparent px-1 pb-1 text-center text-2xl
+			font-light placeholder-neutral-500 outline-none transition dark:text-white"
 			bind:innerText={username}
 			spellcheck="false"
 		></span>

--- a/docs/src/previews/progress.svelte
+++ b/docs/src/previews/progress.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import NumberFlow from "@number-flow/svelte";
 	import Preview from "@components/preview.svelte";
+	import {  } from "svelte";
 	import { Progress } from "melt/builders";
 	import { Spring } from "svelte/motion";
 
@@ -40,11 +41,31 @@
 		};
 	});
 
+	$effect(() => {
+		const observer = new MutationObserver((records) => {
+			const htmlEl = records[0].target;
+
+			if (htmlEl instanceof HTMLElement) {
+				theme = htmlEl.dataset.theme ?? "light";
+			}
+		});
+
+		const el = document.getElementsByTagName("html")[0];
+		observer.observe(el, { attributes: true });
+
+		return () => {
+			observer.disconnect();
+		}
+	});
+
+	let theme = $state(document ? document.getElementsByTagName("html")[0].dataset.theme ?? "light" : "dark");
+
 	const h = 34;
 	const maxS = 81.01;
 	const s = $derived(Math.min(scaleConvert(value, [0, 60], [0, maxS]), maxS));
-	const minL = 65.1;
-	const l = $derived(clamp(minL, scaleConvert(value, [0, 80], [100, minL]), 100));
+	let minL = $derived(theme === "dark" ? 65.1 : 100);
+	let maxL = $derived(theme === "dark" ? 100 : 65.1);
+	const l = $derived(clamp(minL, scaleConvert(value, [0, 80], [maxL, minL]), maxL));
 	const color = $derived(`hsl(${h}, ${s}%, ${l}%)`);
 </script>
 
@@ -55,7 +76,7 @@
 		</span>
 		<div
 			{...progress.root}
-			class="relative w-[300px] overflow-hidden rounded-full bg-neutral-700"
+			class="relative w-[300px] overflow-hidden rounded-full dark:bg-neutral-700 bg-neutral-500"
 			style:height={`${scaleConvert(value, [0, 100], [8, 24])}px`}
 		>
 			<div

--- a/docs/src/previews/progress.svelte
+++ b/docs/src/previews/progress.svelte
@@ -33,57 +33,51 @@
 	$effect(() => {
 		const interval = setInterval(() => {
 			spring.target = Math.round(Math.random() * 100);
-		}, 3000);
+		}, 2000);
 
 		return () => {
 			clearInterval(interval);
 		};
 	});
 
-	let theme = $state("light");
+	const dark = {
+		h: 34,
+		maxS: 81.01,
+		s: () => Math.min(scaleConvert(value, [0, 60], [0, dark.maxS]), dark.maxS),
+		minL: 65.1,
+		l: () => clamp(dark.minL, scaleConvert(value, [0, 80], [100, dark.minL]), 100),
+	};
 
-	$effect.pre(() => {
-		theme = document ? document.getElementsByTagName("html")[0].dataset.theme ?? "light" : "dark";
+	const darkClr = $derived(`hsl(${dark.h}, ${dark.s()}%, ${dark.l()}%)`);
 
-		const observer = new MutationObserver((records) => {
-			const htmlEl = records[0].target;
+	const light = {
+		h: 34,
+		maxS: 81.01,
+		s: () => Math.min(scaleConvert(value, [0, 60], [0, light.maxS]), light.maxS),
+		maxL: 65.1,
+		l: () => clamp(40, scaleConvert(value, [0, 80], [0, light.maxL]), light.maxL),
+	};
 
-			if (htmlEl instanceof HTMLElement) {
-				theme = htmlEl.dataset.theme ?? "light";
-			}
-		});
+	const lightClr = $derived(`hsl(${light.h}, ${light.s()}%, ${light.l()}%)`);
 
-		const el = document.getElementsByTagName("html")[0];
-		observer.observe(el, { attributes: true });
-
-		return () => {
-			observer.disconnect();
-		}
-	});
-
-	const h = 34;
-	const maxS = 81.01;
-	const s = $derived(Math.min(scaleConvert(value, [0, 60], [0, maxS]), maxS));
-	let minL = $derived(theme === "dark" ? 65.1 : 100);
-	let maxL = $derived(theme === "dark" ? 100 : 65.1);
-	const l = $derived(clamp(minL, scaleConvert(value, [0, 80], [maxL, minL]), maxL));
-	const color = $derived(`hsl(${h}, ${s}%, ${l}%)`);
+	const clrClasses = "text-[--light] dark:text-[--dark]";
+	const bgClasses = "bg-[--light] dark:bg-[--dark]";
+	const clrStyle = $derived(`--light: ${lightClr}; --dark: ${darkClr};`);
 </script>
 
 <Preview class="place-content-center">
-	<div class="flex flex-col items-center gap-2">
-		<span class="origin-bottom" style:scale={scaleConvert(value, [0, 100], [1, 2])} style:color>
+	<div class="flex flex-col items-center gap-2" style={clrStyle}>
+		<span class={["origin-bottom", clrClasses]} style:scale={scaleConvert(value, [0, 100], [1, 2])}>
 			<NumberFlow {value} suffix="%" class="font-semibold" />
 		</span>
 		<div
 			{...progress.root}
-			class="relative w-[300px] overflow-hidden rounded-full dark:bg-neutral-700 bg-neutral-500"
+			class="relative w-[300px] overflow-hidden rounded-full bg-neutral-200 dark:bg-neutral-700"
 			style:height={`${scaleConvert(value, [0, 100], [8, 24])}px`}
 		>
 			<div
 				{...progress.progress}
-				class="h-full w-full -translate-x-[var(--progress)]"
-				style:background-color={color}
+				class={["h-full w-full -translate-x-[var(--progress)]", bgClasses]}
 			></div>
 		</div>
 	</div>

--- a/docs/src/previews/progress.svelte
+++ b/docs/src/previews/progress.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import NumberFlow from "@number-flow/svelte";
 	import Preview from "@components/preview.svelte";
-	import {  } from "svelte";
 	import { Progress } from "melt/builders";
 	import { Spring } from "svelte/motion";
 
@@ -41,7 +40,11 @@
 		};
 	});
 
-	$effect(() => {
+	let theme = $state("light");
+
+	$effect.pre(() => {
+		theme = document ? document.getElementsByTagName("html")[0].dataset.theme ?? "light" : "dark";
+
 		const observer = new MutationObserver((records) => {
 			const htmlEl = records[0].target;
 
@@ -57,8 +60,6 @@
 			observer.disconnect();
 		}
 	});
-
-	let theme = $state(document ? document.getElementsByTagName("html")[0].dataset.theme ?? "light" : "dark");
 
 	const h = 34;
 	const maxS = 81.01;

--- a/docs/src/previews/radio-group.svelte
+++ b/docs/src/previews/radio-group.svelte
@@ -50,7 +50,7 @@
 <Preview>
 	<div class="mx-auto flex w-fit flex-col gap-2" {...group.root}>
 		<!-- svelte-ignore a11y_label_has_associated_control -- https://github.com/sveltejs/svelte/issues/15067 -->
-		<label {...group.label} class="font-semibold text-white">Layout</label>
+		<label {...group.label} class="font-semibold">Layout</label>
 		<div class="flex {isVert ? 'flex-col gap-1' : 'flex-row gap-3'}">
 			{#each items as i}
 				{@const item = group.getItem(i)}
@@ -71,7 +71,7 @@
 						{/if}
 					</div>
 
-					<span class="font-medium capitalize leading-none text-gray-100">
+					<span class="font-medium capitalize leading-none dark:text-gray-100 text-gray-600">
 						{i}
 					</span>
 				</div>

--- a/docs/src/previews/radio-group.svelte
+++ b/docs/src/previews/radio-group.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import Preview from "@components/preview.svelte";
-	import { scale } from "svelte/transition";
 	import { RadioGroup } from "melt/builders";
 	import { getters } from "melt/builders";
 	import { usePreviewControls } from "@components/preview-ctx.svelte";
@@ -50,7 +49,7 @@
 <Preview>
 	<div class="mx-auto flex w-fit flex-col gap-2" {...group.root}>
 		<!-- svelte-ignore a11y_label_has_associated_control -- https://github.com/sveltejs/svelte/issues/15067 -->
-		<label {...group.label} class="font-semibold">Layout</label>
+		<label {...group.label} class="font-medium">Layout</label>
 		<div class="flex {isVert ? 'flex-col gap-1' : 'flex-row gap-3'}">
 			{#each items as i}
 				{@const item = group.getItem(i)}
@@ -60,18 +59,24 @@
 					{...item.attrs}
 				>
 					<div
-						class="grid h-6 w-6 place-items-center
-							rounded-full bg-white shadow-sm hover:bg-gray-100 data-[disabled=true]:bg-gray-400"
+						class={[
+							"grid h-6 w-6 place-items-center rounded-full border shadow-sm",
+							"hover:bg-gray-100 data-[disabled=true]:bg-gray-400",
+							item.checked
+								? "bg-accent-500 border-accent-500 dark:bg-white"
+								: "border-neutral-400 bg-neutral-100",
+							"dark:border-white",
+						]}
 					>
 						{#if item.checked}
 							<div
-								transition:scale={{ duration: 150, opacity: 1 }}
-								class="bg-accent-500 h-3 w-3 rounded-full"
+								class={["h-3 w-3 rounded-full", item.checked && "dark:bg-accent-500 bg-white"]}
+								aria-hidden="true"
 							></div>
 						{/if}
 					</div>
 
-					<span class="font-medium capitalize leading-none dark:text-gray-100 text-gray-600">
+					<span class="font-semibold capitalize leading-none text-gray-600 dark:text-gray-100">
 						{i}
 					</span>
 				</div>


### PR DESCRIPTION
Radio Group and Avatar previews had incorrect text color, this small PR fixes it.
Before
![405902025-29c0db56-0dc0-432a-abb1-e0f66052bd12](https://github.com/user-attachments/assets/772190ba-3891-45da-a6ef-e9a19dedf55b)
After
![405902157-4beef52c-a8e0-4594-81f2-9db5e0b4f270](https://github.com/user-attachments/assets/1bb3a3ae-981b-4c7e-a79c-754dc5372bf4)
