### PR TITLE
Fix toggle accessibility

### DIFF
--- a/.changeset/pink-goats-protect.md
+++ b/.changeset/pink-goats-protect.md
@@ -1,0 +1,5 @@
+---
+"melt": patch
+---
+
+fix toggle accessibility

--- a/docs/src/api.json
+++ b/docs/src/api.json
@@ -16,7 +16,7 @@
       {
         "name": "selected",
         "type": "MaybeMultiple<Multiple> | undefined",
-        "description": "The currently selected item(s).\nIf `multiple` is `true`, this should be an `Iterable`.\nOtherwise, it'll be a `string`.",
+        "description": "The currently selected item(s).\r\nIf `multiple` is `true`, this should be an `Iterable`.\r\nOtherwise, it'll be a `string`.",
         "defaultValue": "undefined",
         "optional": true
       },
@@ -64,37 +64,37 @@
       {
         "name": "isSelected",
         "type": "(id: string) => boolean",
-        "description": "Checks if an item is currently selected\n@param id - ID of the item to check"
+        "description": "Checks if an item is currently selected\r@param id - ID of the item to check"
       },
       {
         "name": "isExpanded",
         "type": "(id: string) => boolean",
-        "description": "Checks if an item is currently expanded\n@param id - ID of the item to check"
+        "description": "Checks if an item is currently expanded\r@param id - ID of the item to check"
       },
       {
         "name": "expand",
         "type": "(id: string) => void",
-        "description": "Expands a specific item\n@param id - ID of the item to expand"
+        "description": "Expands a specific item\r@param id - ID of the item to expand"
       },
       {
         "name": "collapse",
         "type": "(id: string) => void",
-        "description": "Collapses a specific item\n@param id - ID of the item to collapse"
+        "description": "Collapses a specific item\r@param id - ID of the item to collapse"
       },
       {
         "name": "toggleExpand",
         "type": "(id: string) => void",
-        "description": "Toggles the expanded state of an item\n@param id - ID of the item to toggle"
+        "description": "Toggles the expanded state of an item\r@param id - ID of the item to toggle"
       },
       {
         "name": "select",
         "type": "(id: string) => void",
-        "description": "Selects a specific item\n@param id - ID of the item to select"
+        "description": "Selects a specific item\r@param id - ID of the item to select"
       },
       {
         "name": "deselect",
         "type": "(id: string) => void",
-        "description": "Deselects a specific item\n@param id - ID of the item to deselect"
+        "description": "Deselects a specific item\r@param id - ID of the item to deselect"
       },
       {
         "name": "clearSelection",
@@ -104,27 +104,27 @@
       {
         "name": "toggleSelect",
         "type": "(id: string) => void",
-        "description": "Toggles the selected state of an item\n@param id - ID of the item to toggle"
+        "description": "Toggles the selected state of an item\r@param id - ID of the item to toggle"
       },
       {
         "name": "selectAll",
         "type": "() => void",
-        "description": "Selects all visible items.\nIf all items are already selected, clears the selection."
+        "description": "Selects all visible items.\rIf all items are already selected, clears the selection."
       },
       {
         "name": "getItemId",
         "type": "(id: string) => string",
-        "description": "Gets the DOM ID for a specific tree item\n@param id - ID of the item"
+        "description": "Gets the DOM ID for a specific tree item\r@param id - ID of the item"
       },
       {
         "name": "getItemEl",
         "type": "(id: string) => HTMLElement | null",
-        "description": "Gets the DOM element for a specific tree item\n@param id - ID of the item"
+        "description": "Gets the DOM element for a specific tree item\r@param id - ID of the item"
       },
       {
         "name": "selectUntil",
         "type": "(id: string) => void",
-        "description": "Selects all items between the last selected item and the specified item\n@param id - ID of the item to select until"
+        "description": "Selects all items between the last selected item and the specified item\r@param id - ID of the item to select until"
       },
       {
         "name": "typeahead",
@@ -156,7 +156,7 @@
       {
         "name": "selected",
         "type": "Value<FalseIfUndefined<Multiple>>",
-        "description": "Currently selected item(s)\nFor multiple selection, returns a Set of IDs\nFor single selection, returns a single ID or undefined"
+        "description": "Currently selected item(s)\rFor multiple selection, returns a Set of IDs\rFor single selection, returns a single ID or undefined"
       },
       {
         "name": "expanded",
@@ -179,14 +179,14 @@
         "description": "Array of Child instances representing the top-level items"
       }
     ],
-    "propsAlt": "export type TreeProps<Items extends TreeItem[], Multiple extends boolean = false> = {\n  /**\n   * If `true`, the user can select multiple items.\n   * @default false\n   */\n  multiple?: MaybeGetter<Multiple | undefined>;\n  /**\n   * The currently selected item(s).\n   * If `multiple` is `true`, this should be an `Iterable`.\n   * Otherwise, it'll be a `string`.\n   * @default undefined\n   */\n  selected?: MaybeMultiple<Multiple>;\n  /**\n   * Callback fired when selection changes\n   * @param value - For multiple selection, a Set of selected IDs. For single selection, a single ID or undefined\n   */\n  onSelectedChange?: (value: Multiple extends true ? Set<string> : string | undefined) => void;\n  /**\n   * The currently expanded items\n   *\n   * @default undefined\n   */\n  expanded?: MaybeMultiple<true>;\n  /**\n   * Callback fired when expanded state changes\n   * @param value - Set of expanded item IDs\n   */\n  onExpandedChange?: (value: Set<string>) => void;\n  /**\n   * If `true`, groups (items with children) expand on click.\n   * @default true\n   */\n  expandOnClick?: MaybeGetter<boolean | undefined>;\n  /**\n   * The items contained in the tree.\n   * @required\n   */\n  items: Items;\n  /**\n   * How many time (in ms) the typeahead string is held before it is cleared\n   * @default 500\n   */\n  typeaheadTimeout?: MaybeGetter<number>;\n};"
+    "propsAlt": "export type TreeProps<Items extends TreeItem[], Multiple extends boolean = false> = {\r\n  /**\r\n   * If `true`, the user can select multiple items.\r\n   * @default false\r\n   */\r\n  multiple?: MaybeGetter<Multiple | undefined>;\r\n  /**\r\n   * The currently selected item(s).\r\n   * If `multiple` is `true`, this should be an `Iterable`.\r\n   * Otherwise, it'll be a `string`.\r\n   * @default undefined\r\n   */\r\n  selected?: MaybeMultiple<Multiple>;\r\n  /**\r\n   * Callback fired when selection changes\r\n   * @param value - For multiple selection, a Set of selected IDs. For single selection, a single ID or undefined\r\n   */\r\n  onSelectedChange?: (value: Multiple extends true ? Set<string> : string | undefined) => void;\r\n  /**\r\n   * The currently expanded items\r\n   *\r\n   * @default undefined\r\n   */\r\n  expanded?: MaybeMultiple<true>;\r\n  /**\r\n   * Callback fired when expanded state changes\r\n   * @param value - Set of expanded item IDs\r\n   */\r\n  onExpandedChange?: (value: Set<string>) => void;\r\n  /**\r\n   * If `true`, groups (items with children) expand on click.\r\n   * @default true\r\n   */\r\n  expandOnClick?: MaybeGetter<boolean | undefined>;\r\n  /**\r\n   * The items contained in the tree.\r\n   * @required\r\n   */\r\n  items: Items;\r\n  /**\r\n   * How many time (in ms) the typeahead string is held before it is cleared\r\n   * @default 500\r\n   */\r\n  typeaheadTimeout?: MaybeGetter<number>;\r\n};"
   },
   "Toggle": {
     "constructorProps": [
       {
         "name": "value",
         "type": "MaybeGetter<boolean> | undefined",
-        "description": "The value for the Toggle.\n\nWhen passing a getter, it will be used as source of truth,\nmeaning that the value only changes when the getter returns a new value.\n\nOtherwise, if passing a static value, it'll serve as the default value.",
+        "description": "The value for the Toggle.\r\n\r\nWhen passing a getter, it will be used as source of truth,\r\nmeaning that the value only changes when the getter returns a new value.\r\n\r\nOtherwise, if passing a static value, it'll serve as the default value.",
         "defaultValue": "false",
         "optional": true
       },
@@ -218,7 +218,7 @@
       },
       {
         "name": "trigger",
-        "type": "{\n  readonly \"data-melt-toggle-trigger\": \"\"\n  readonly \"data-checked\": \"\" | undefined\n  readonly disabled: true | undefined\n  readonly onclick: () => void\n}",
+        "type": "{\n  readonly \"data-melt-toggle-trigger\": \"\"\n  readonly \"data-checked\": \"\" | undefined\n  readonly \"aria-pressed\": boolean\n  readonly disabled: true | undefined\n  readonly onclick: () => void\n}",
         "description": "The trigger that toggles the value."
       },
       {
@@ -227,7 +227,7 @@
         "description": "A hidden input field to use within forms."
       }
     ],
-    "propsAlt": "export type ToggleProps = {\n  /**\n   * The value for the Toggle.\n   *\n   * When passing a getter, it will be used as source of truth,\n   * meaning that the value only changes when the getter returns a new value.\n   *\n   * Otherwise, if passing a static value, it'll serve as the default value.\n   *\n   *\n   * @default false\n   */\n  value?: MaybeGetter<boolean>;\n  /**\n   * Called when the value is supposed to change.\n   */\n  onValueChange?: (value: boolean) => void;\n\n  /**\n   * If `true`, prevents the user from interacting with the input.\n   *\n   * @default false\n   */\n  disabled?: MaybeGetter<boolean | undefined>;\n};"
+    "propsAlt": "export type ToggleProps = {\r\n  /**\r\n   * The value for the Toggle.\r\n   *\r\n   * When passing a getter, it will be used as source of truth,\r\n   * meaning that the value only changes when the getter returns a new value.\r\n   *\r\n   * Otherwise, if passing a static value, it'll serve as the default value.\r\n   *\r\n   *\r\n   * @default false\r\n   */\r\n  value?: MaybeGetter<boolean>;\r\n  /**\r\n   * Called when the value is supposed to change.\r\n   */\r\n  onValueChange?: (value: boolean) => void;\r\n\r\n  /**\r\n   * If `true`, prevents the user from interacting with the input.\r\n   *\r\n   * @default false\r\n   */\r\n  disabled?: MaybeGetter<boolean | undefined>;\r\n};"
   },
   "Tabs": {
     "constructorProps": [
@@ -255,7 +255,7 @@
       {
         "name": "value",
         "type": "MaybeGetter<T | undefined>",
-        "description": "The default value for `tabs.value`\n\nWhen passing a getter, it will be used as source of truth,\nmeaning that `tabs.value` only changes when the getter returns a new value.\n\nIf omitted, it will use the first tab as default.",
+        "description": "The default value for `tabs.value`\r\n\r\nWhen passing a getter, it will be used as source of truth,\r\nmeaning that `tabs.value` only changes when the getter returns a new value.\r\n\r\nIf omitted, it will use the first tab as default.",
         "defaultValue": "undefined",
         "optional": true
       },
@@ -305,7 +305,7 @@
         "description": "The attributes for the list that contains the tab triggers."
       }
     ],
-    "propsAlt": "export type TabsProps<T extends string = string> = {\n  /**\n   * If `true`, the value will be changed whenever a trigger is focused.\n   *\n   * @default true\n   */\n  selectWhenFocused?: MaybeGetter<boolean | undefined>;\n  /**\n   * If the the trigger selection should loop when navigating with the arrow keys.\n   *\n   * @default true\n   */\n  loop?: MaybeGetter<boolean | undefined>;\n  /**\n   * The orientation of the tabs.\n   *\n   * @default \"horizontal\"\n   */\n  orientation?: MaybeGetter<\"horizontal\" | \"vertical\" | undefined>;\n  /**\n   * The default value for `tabs.value`\n   *\n   * When passing a getter, it will be used as source of truth,\n   * meaning that `tabs.value` only changes when the getter returns a new value.\n   *\n   * If omitted, it will use the first tab as default.\n   *\n   * @default undefined\n   */\n  value?: MaybeGetter<T | undefined>;\n  /**\n   * Called when the `Tabs` instance tries to change the active tab.\n   */\n  onValueChange?: (active: T) => void;\n};"
+    "propsAlt": "export type TabsProps<T extends string = string> = {\r\n  /**\r\n   * If `true`, the value will be changed whenever a trigger is focused.\r\n   *\r\n   * @default true\r\n   */\r\n  selectWhenFocused?: MaybeGetter<boolean | undefined>;\r\n  /**\r\n   * If the the trigger selection should loop when navigating with the arrow keys.\r\n   *\r\n   * @default true\r\n   */\r\n  loop?: MaybeGetter<boolean | undefined>;\r\n  /**\r\n   * The orientation of the tabs.\r\n   *\r\n   * @default \"horizontal\"\r\n   */\r\n  orientation?: MaybeGetter<\"horizontal\" | \"vertical\" | undefined>;\r\n  /**\r\n   * The default value for `tabs.value`\r\n   *\r\n   * When passing a getter, it will be used as source of truth,\r\n   * meaning that `tabs.value` only changes when the getter returns a new value.\r\n   *\r\n   * If omitted, it will use the first tab as default.\r\n   *\r\n   * @default undefined\r\n   */\r\n  value?: MaybeGetter<T | undefined>;\r\n  /**\r\n   * Called when the `Tabs` instance tries to change the active tab.\r\n   */\r\n  onValueChange?: (active: T) => void;\r\n};"
   },
   "Slider": {
     "constructorProps": [
@@ -340,7 +340,7 @@
       {
         "name": "value",
         "type": "MaybeGetter<number | undefined>",
-        "description": "The default value for `tabs.value`\n\nWhen passing a getter, it will be used as source of truth,\nmeaning that `tabs.value` only changes when the getter returns a new value.\n\nIf omitted, it will use the first tab as default.",
+        "description": "The default value for `tabs.value`\r\n\r\nWhen passing a getter, it will be used as source of truth,\r\nmeaning that `tabs.value` only changes when the getter returns a new value.\r\n\r\nIf omitted, it will use the first tab as default.",
         "defaultValue": "undefined",
         "optional": true
       },
@@ -381,7 +381,7 @@
       {
         "name": "root",
         "type": "{\n  readonly \"data-dragging\": \"\" | undefined\n  readonly \"data-value\": number\n  readonly \"data-orientation\": \"horizontal\" | \"vertical\"\n  readonly \"aria-valuenow\": number\n  readonly \"aria-valuemin\": number\n  readonly \"aria-valuemax\": number\n  readonly \"aria-orientation\": \"horizontal\" | \"vertical\"\n  readonly style: `--percentage: ${string}; --percentage-inv: ${string}; touch-action: ${string}`\n  readonly tabindex: 0\n  readonly role: \"slider\"\n  readonly \"data-melt-slider-root\": \"\"\n  readonly id: string\n  readonly onpointerdown: (e: PointerEvent) => void\n  readonly onkeydown: (e: KeyboardEvent) => void\n}",
-        "description": "The root of the slider.\nAny cursor interaction along this element will change the slider's values."
+        "description": "The root of the slider.\rAny cursor interaction along this element will change the slider's values."
       },
       {
         "name": "thumb",
@@ -389,7 +389,7 @@
         "description": "The slider's thumb, positioned at the end of the range."
       }
     ],
-    "propsAlt": "export type SliderProps = {\n  /**\n   * The minimum value of the slider.\n   *\n   * @default 0\n   */\n  min?: MaybeGetter<number | undefined>;\n  /**\n   * The maximum value of the slider.\n   *\n   * @default 100\n   */\n  max?: MaybeGetter<number | undefined>;\n  /**\n   * The orientation of the slider.\n   *\n   * @default \"horizontal\"\n   */\n  orientation?: MaybeGetter<\"horizontal\" | \"vertical\" | undefined>;\n\n  /**\n   * The step size of the slider.\n   *\n   * @default 1\n   */\n  step?: MaybeGetter<number | undefined>;\n  /**\n   * The default value for `tabs.value`\n   *\n   * When passing a getter, it will be used as source of truth,\n   * meaning that `tabs.value` only changes when the getter returns a new value.\n   *\n   * If omitted, it will use the first tab as default.\n   *\n   * @default undefined\n   */\n  value?: MaybeGetter<number | undefined>;\n  /**\n   * Called when the `Slider` instance tries to change the active tab.\n   */\n  onValueChange?: (active: number) => void;\n};"
+    "propsAlt": "export type SliderProps = {\r\n  /**\r\n   * The minimum value of the slider.\r\n   *\r\n   * @default 0\r\n   */\r\n  min?: MaybeGetter<number | undefined>;\r\n  /**\r\n   * The maximum value of the slider.\r\n   *\r\n   * @default 100\r\n   */\r\n  max?: MaybeGetter<number | undefined>;\r\n  /**\r\n   * The orientation of the slider.\r\n   *\r\n   * @default \"horizontal\"\r\n   */\r\n  orientation?: MaybeGetter<\"horizontal\" | \"vertical\" | undefined>;\r\n\r\n  /**\r\n   * The step size of the slider.\r\n   *\r\n   * @default 1\r\n   */\r\n  step?: MaybeGetter<number | undefined>;\r\n  /**\r\n   * The default value for `tabs.value`\r\n   *\r\n   * When passing a getter, it will be used as source of truth,\r\n   * meaning that `tabs.value` only changes when the getter returns a new value.\r\n   *\r\n   * If omitted, it will use the first tab as default.\r\n   *\r\n   * @default undefined\r\n   */\r\n  value?: MaybeGetter<number | undefined>;\r\n  /**\r\n   * Called when the `Slider` instance tries to change the active tab.\r\n   */\r\n  onValueChange?: (active: number) => void;\r\n};"
   },
   "Select": {
     "constructorProps": [],
@@ -408,7 +408,7 @@
       {
         "name": "required",
         "type": "MaybeGetter<boolean | undefined>",
-        "description": "If `true`, indicates that the user must select a radio button before\nthe owning form can be submitted.",
+        "description": "If `true`, indicates that the user must select a radio button before\r\nthe owning form can be submitted.",
         "defaultValue": "false",
         "optional": true
       },
@@ -512,7 +512,7 @@
         "description": ""
       }
     ],
-    "propsAlt": "export type RadioGroupProps = {\n  /**\n   * If `true`, prevents the user from interacting with the group.\n   *\n   * @default false\n   */\n  disabled?: MaybeGetter<boolean | undefined>;\n  /**\n   * If `true`, indicates that the user must select a radio button before\n   * the owning form can be submitted.\n   *\n   * @default false\n   */\n  required?: MaybeGetter<boolean | undefined>;\n  /**\n   * If the the button selection should loop when navigating with the arrow keys.\n   *\n   * @default true\n   */\n  loop?: MaybeGetter<boolean | undefined>;\n  /**\n   * If `true`, the value will be changed whenever a button is focused.\n   *\n   * @default true\n   */\n  selectWhenFocused?: MaybeGetter<boolean | undefined>;\n  /**\n   * The orientation of the slider.\n   *\n   * @default \"vertical\"\n   */\n  orientation?: MaybeGetter<\"horizontal\" | \"vertical\" | undefined>;\n  /**\n   * Input name for radio group.\n   */\n  name?: MaybeGetter<string | undefined>;\n  /**\n   * Default value for radio group.\n   *\n   * @default \"\"\n   */\n  value?: MaybeGetter<string | undefined>;\n  /**\n   * Called when the radio button is clicked.\n   */\n  onValueChange?: (active: string) => void;\n};"
+    "propsAlt": "export type RadioGroupProps = {\r\n  /**\r\n   * If `true`, prevents the user from interacting with the group.\r\n   *\r\n   * @default false\r\n   */\r\n  disabled?: MaybeGetter<boolean | undefined>;\r\n  /**\r\n   * If `true`, indicates that the user must select a radio button before\r\n   * the owning form can be submitted.\r\n   *\r\n   * @default false\r\n   */\r\n  required?: MaybeGetter<boolean | undefined>;\r\n  /**\r\n   * If the the button selection should loop when navigating with the arrow keys.\r\n   *\r\n   * @default true\r\n   */\r\n  loop?: MaybeGetter<boolean | undefined>;\r\n  /**\r\n   * If `true`, the value will be changed whenever a button is focused.\r\n   *\r\n   * @default true\r\n   */\r\n  selectWhenFocused?: MaybeGetter<boolean | undefined>;\r\n  /**\r\n   * The orientation of the slider.\r\n   *\r\n   * @default \"vertical\"\r\n   */\r\n  orientation?: MaybeGetter<\"horizontal\" | \"vertical\" | undefined>;\r\n  /**\r\n   * Input name for radio group.\r\n   */\r\n  name?: MaybeGetter<string | undefined>;\r\n  /**\r\n   * Default value for radio group.\r\n   *\r\n   * @default \"\"\r\n   */\r\n  value?: MaybeGetter<string | undefined>;\r\n  /**\r\n   * Called when the radio button is clicked.\r\n   */\r\n  onValueChange?: (active: string) => void;\r\n};"
   },
   "Progress": {
     "constructorProps": [
@@ -556,17 +556,17 @@
       {
         "name": "progress",
         "type": "{\n  \"data-melt-progress-progress\": string\n  style: `--progress: ${string}`\n}",
-        "description": "Spread attributes for the Progress percentage element.\nProvides a --progress CSS variable that can be used to style the progress:\n`transform: translateX(calc(var(--progress) * -1));`"
+        "description": "Spread attributes for the Progress percentage element.\rProvides a --progress CSS variable that can be used to style the progress:\r`transform: translateX(calc(var(--progress) * -1));`"
       }
     ],
-    "propsAlt": "export type ProgressProps = {\n  /**\n   * The value for the progress.\n   * \n   * @default undefined\n   */\n  value?: MaybeGetter<number | undefined>;\n\n  /**\n   * The maximum value of the progress.\n   * \n   * @deafult 100\n   */\n  max?: MaybeGetter<number | undefined>;\n\n  /**\n   * The callback invoked when the value of the progress changes.\n   */\n  onValueChange?: (value: number) => void;\n};"
+    "propsAlt": "export type ProgressProps = {\r\n  /**\r\n   * The value for the progress.\r\n   * \r\n   * @default undefined\r\n   */\r\n  value?: MaybeGetter<number | undefined>;\r\n\r\n  /**\r\n   * The maximum value of the progress.\r\n   * \r\n   * @deafult 100\r\n   */\r\n  max?: MaybeGetter<number | undefined>;\r\n\r\n  /**\r\n   * The callback invoked when the value of the progress changes.\r\n   */\r\n  onValueChange?: (value: number) => void;\r\n};"
   },
   "Popover": {
     "constructorProps": [
       {
         "name": "open",
         "type": "MaybeGetter<boolean> | undefined",
-        "description": "If the Popover is open.\n\nWhen passing a getter, it will be used as source of truth,\nmeaning that the value only changes when the getter returns a new value.\n\nOtherwise, if passing a static value, it'll serve as the default value.",
+        "description": "If the Popover is open.\r\n\r\nWhen passing a getter, it will be used as source of truth,\r\nmeaning that the value only changes when the getter returns a new value.\r\n\r\nOtherwise, if passing a static value, it'll serve as the default value.",
         "defaultValue": "false",
         "optional": true
       },
@@ -618,14 +618,14 @@
         "description": ""
       }
     ],
-    "propsAlt": "export type PopoverProps = {\n  /**\n   * If the Popover is open.\n   *\n   * When passing a getter, it will be used as source of truth,\n   * meaning that the value only changes when the getter returns a new value.\n   *\n   * Otherwise, if passing a static value, it'll serve as the default value.\n   *\n   *\n   * @default false\n   */\n  open?: MaybeGetter<boolean>;\n\n  /**\n   * Called when the value is supposed to change.\n   */\n  onOpenChange?: (value: boolean) => void;\n\n  /**\n   * If the popover visibility should be controlled by the user.\n   *\n   * @default false\n   */\n  forceVisible?: MaybeGetter<boolean | undefined>;\n\n  /**\n   * Options to be passed to Floating UI's `computePosition`\n   *\n   * @see https://floating-ui.com/docs/computePosition\n   */\n  computePositionOptions?: MaybeGetter<Partial<ComputePositionConfig> | undefined>;\n};"
+    "propsAlt": "export type PopoverProps = {\r\n  /**\r\n   * If the Popover is open.\r\n   *\r\n   * When passing a getter, it will be used as source of truth,\r\n   * meaning that the value only changes when the getter returns a new value.\r\n   *\r\n   * Otherwise, if passing a static value, it'll serve as the default value.\r\n   *\r\n   *\r\n   * @default false\r\n   */\r\n  open?: MaybeGetter<boolean>;\r\n\r\n  /**\r\n   * Called when the value is supposed to change.\r\n   */\r\n  onOpenChange?: (value: boolean) => void;\r\n\r\n  /**\r\n   * If the popover visibility should be controlled by the user.\r\n   *\r\n   * @default false\r\n   */\r\n  forceVisible?: MaybeGetter<boolean | undefined>;\r\n\r\n  /**\r\n   * Options to be passed to Floating UI's `computePosition`\r\n   *\r\n   * @see https://floating-ui.com/docs/computePosition\r\n   */\r\n  computePositionOptions?: MaybeGetter<Partial<ComputePositionConfig> | undefined>;\r\n};"
   },
   "PinInput": {
     "constructorProps": [
       {
         "name": "value",
         "type": "MaybeGetter<string | undefined>",
-        "description": "The value for the Pin Input.\n\nWhen passing a getter, it will be used as source of truth,\nmeaning that the value only changes when the getter returns a new value.\n\nOtherwise, if passing a static value, it'll serve as the default value.",
+        "description": "The value for the Pin Input.\r\n\r\nWhen passing a getter, it will be used as source of truth,\r\nmeaning that the value only changes when the getter returns a new value.\r\n\r\nOtherwise, if passing a static value, it'll serve as the default value.",
         "defaultValue": "''",
         "optional": true
       },
@@ -719,7 +719,7 @@
         "description": "An array of props that should be spread to the input elements."
       }
     ],
-    "propsAlt": "export type PinInputProps = {\n  /**\n   * The value for the Pin Input.\n   *\n   * When passing a getter, it will be used as source of truth,\n   * meaning that the value only changes when the getter returns a new value.\n   *\n   * Otherwise, if passing a static value, it'll serve as the default value.\n   *\n   *\n   * @default ''\n   */\n  value?: MaybeGetter<string | undefined>;\n  /**\n   * Called when the `PinInput` instance tries to change the value.\n   */\n  onValueChange?: (value: string) => void;\n\n  /**\n   * The amount of digits in the Pin Input.\n   *\n   * @default 4\n   */\n  maxLength?: MaybeGetter<number | undefined>;\n  /**\n   * An optional placeholder to display when the input is empty.\n   *\n   * @default '○'\n   */\n  placeholder?: MaybeGetter<string | undefined>;\n\n  /**\n   * If `true`, prevents the user from interacting with the input.\n   *\n   * @default false\n   */\n  disabled?: MaybeGetter<boolean | undefined>;\n\n  /**\n   * If the input should be masked like a password.\n   *\n   * @default false\n   */\n  mask?: MaybeGetter<boolean | undefined>;\n\n  /**\n   * What characters the input accepts.\n   *\n   * @default 'text'\n   */\n  type?: MaybeGetter<\"alphanumeric\" | \"numeric\" | \"text\" | undefined>;\n};"
+    "propsAlt": "export type PinInputProps = {\r\n  /**\r\n   * The value for the Pin Input.\r\n   *\r\n   * When passing a getter, it will be used as source of truth,\r\n   * meaning that the value only changes when the getter returns a new value.\r\n   *\r\n   * Otherwise, if passing a static value, it'll serve as the default value.\r\n   *\r\n   *\r\n   * @default ''\r\n   */\r\n  value?: MaybeGetter<string | undefined>;\r\n  /**\r\n   * Called when the `PinInput` instance tries to change the value.\r\n   */\r\n  onValueChange?: (value: string) => void;\r\n\r\n  /**\r\n   * The amount of digits in the Pin Input.\r\n   *\r\n   * @default 4\r\n   */\r\n  maxLength?: MaybeGetter<number | undefined>;\r\n  /**\r\n   * An optional placeholder to display when the input is empty.\r\n   *\r\n   * @default '○'\r\n   */\r\n  placeholder?: MaybeGetter<string | undefined>;\r\n\r\n  /**\r\n   * If `true`, prevents the user from interacting with the input.\r\n   *\r\n   * @default false\r\n   */\r\n  disabled?: MaybeGetter<boolean | undefined>;\r\n\r\n  /**\r\n   * If the input should be masked like a password.\r\n   *\r\n   * @default false\r\n   */\r\n  mask?: MaybeGetter<boolean | undefined>;\r\n\r\n  /**\r\n   * What characters the input accepts.\r\n   *\r\n   * @default 'text'\r\n   */\r\n  type?: MaybeGetter<\"alphanumeric\" | \"numeric\" | \"text\" | undefined>;\r\n};"
   },
   "Collapsible": {
     "constructorProps": [
@@ -770,7 +770,7 @@
         "description": "The spread attributes for the content element."
       }
     ],
-    "propsAlt": "export type CollapsibleProps = {\n  /**\n   * Whether the collapsible is disabled which prevents it from being opened.\n   */\n  disabled?: MaybeGetter<boolean | undefined>;\n\n  /**\n   * Whether the collapsible is open.\n   */\n  open?: MaybeGetter<boolean | undefined>;\n\n  /**\n   * A callback called when the value of `open` changes.\n   */\n  onOpenChange?: (value: boolean) => void;\n};"
+    "propsAlt": "export type CollapsibleProps = {\r\n  /**\r\n   * Whether the collapsible is disabled which prevents it from being opened.\r\n   */\r\n  disabled?: MaybeGetter<boolean | undefined>;\r\n\r\n  /**\r\n   * Whether the collapsible is open.\r\n   */\r\n  open?: MaybeGetter<boolean | undefined>;\r\n\r\n  /**\r\n   * A callback called when the value of `open` changes.\r\n   */\r\n  onOpenChange?: (value: boolean) => void;\r\n};"
   },
   "Avatar": {
     "constructorProps": [
@@ -822,7 +822,7 @@
         "description": ""
       }
     ],
-    "propsAlt": "export type AvatarProps = {\n  /**\n   * The source of the image to display.\n   */\n  src?: MaybeGetter<string | undefined>;\n\n  /**\n   * The amount of time in milliseconds to wait before displaying the image.\n   *\n   * @default 0\n   */\n  delayMs?: MaybeGetter<number | undefined>;\n\n  /**\n   * A callback invoked when the loading status store of the avatar changes.\n   */\n  onLoadingStatusChange?: (value: ImageLoadingStatus) => void | undefined;\n};"
+    "propsAlt": "export type AvatarProps = {\r\n  /**\r\n   * The source of the image to display.\r\n   */\r\n  src?: MaybeGetter<string | undefined>;\r\n\r\n  /**\r\n   * The amount of time in milliseconds to wait before displaying the image.\r\n   *\r\n   * @default 0\r\n   */\r\n  delayMs?: MaybeGetter<number | undefined>;\r\n\r\n  /**\r\n   * A callback invoked when the loading status store of the avatar changes.\r\n   */\r\n  onLoadingStatusChange?: (value: ImageLoadingStatus) => void | undefined;\r\n};"
   },
   "Accordion": {
     "constructorProps": [
@@ -857,27 +857,27 @@
       {
         "name": "getItem",
         "type": "<Meta extends Record<string, unknown>>(\n  item: AccordionItem<Meta>,\n) => Item<Meta, Multiple>",
-        "description": "Returns an Item class with the necessary\nspread attributes for an accordion item.\n@param item"
+        "description": "Returns an Item class with the necessary\rspread attributes for an accordion item.\r@param item"
       },
       {
         "name": "isExpanded",
         "type": "(id: string) => boolean",
-        "description": "Checks if an item is currently expanded.\n@param id - ID of the item to check."
+        "description": "Checks if an item is currently expanded.\r@param id - ID of the item to check."
       },
       {
         "name": "expand",
         "type": "(id: string) => void",
-        "description": "Expands a specific item.\n@param id - ID of the item to expand."
+        "description": "Expands a specific item.\r@param id - ID of the item to expand."
       },
       {
         "name": "collapse",
         "type": "(id: string) => void",
-        "description": "Collapses a specific item.\n@param id - ID of the item to collapse."
+        "description": "Collapses a specific item.\r@param id - ID of the item to collapse."
       },
       {
         "name": "toggleExpanded",
         "type": "(id: string) => void",
-        "description": "Toggles the expanded state of an item.\n@param id - ID of the item to toggle."
+        "description": "Toggles the expanded state of an item.\r@param id - ID of the item to toggle."
       }
     ],
     "properties": [
@@ -902,6 +902,6 @@
         "description": "Spread attributes for the accordion root element."
       }
     ],
-    "propsAlt": "export type AccordionProps<Multiple extends boolean = false> = {\n  /**\n   * If `true`, multiple accordion items can be open at the same time.\n   *\n   * @default false\n   */\n  multiple?: MaybeGetter<Multiple | undefined>;\n\n  /**\n   * When `true`, prevents the user from interacting with the accordion.\n   *\n   * @default false\n   */\n  disabled?: MaybeGetter<boolean | undefined>;\n\n  /**\n   * The controlled value for the accordion.\n   */\n  value?: AccordionValue<Multiple>;\n\n  /**\n   * The callback invoked when the value of the Accordion changes.\n   */\n  onValueChange?: OnChange<Multiple>;\n};"
+    "propsAlt": "export type AccordionProps<Multiple extends boolean = false> = {\r\n  /**\r\n   * If `true`, multiple accordion items can be open at the same time.\r\n   *\r\n   * @default false\r\n   */\r\n  multiple?: MaybeGetter<Multiple | undefined>;\r\n\r\n  /**\r\n   * When `true`, prevents the user from interacting with the accordion.\r\n   *\r\n   * @default false\r\n   */\r\n  disabled?: MaybeGetter<boolean | undefined>;\r\n\r\n  /**\r\n   * The controlled value for the accordion.\r\n   */\r\n  value?: AccordionValue<Multiple>;\r\n\r\n  /**\r\n   * The callback invoked when the value of the Accordion changes.\r\n   */\r\n  onValueChange?: OnChange<Multiple>;\r\n};"
   }
 }

--- a/docs/src/content/docs/components/toggle.mdx
+++ b/docs/src/content/docs/components/toggle.mdx
@@ -26,6 +26,8 @@ Things I want:
 
 ## Usage
 
+For accessibility reasons, toggle buttons also require the `aria-label` attribute to be set to describe to screen readers what is being enabled/disabled.
+
 <Tabs>
 	<TabItem label="Builder">
 ```svelte
@@ -35,7 +37,7 @@ Things I want:
 	const toggle = new Toggle();
 </script>
 
-<button {...toggle.trigger}>
+<button {...toggle.trigger} aria-label="toggle favourite">
 	{toggle.value ? "✅" : "❌"}
 </button>
 ```

--- a/docs/src/previews/toggle.svelte
+++ b/docs/src/previews/toggle.svelte
@@ -33,6 +33,7 @@
 			  hover:bg-gray-300/25 focus-visible:ring active:bg-gray-300/40 disabled:cursor-not-allowed
 				dark:hover:bg-gray-700 dark:active:bg-gray-600 dark:disabled:bg-gray-900"
 			{...toggle.trigger}
+			aria-label="toggle favourite"
 		>
 			<PhHeartFill
 				class="text-accent-500 dark:text-accent-200 absolute left-1/2 top-1/2 z-10 origin-center -translate-x-1/2 -translate-y-1/2"

--- a/packages/melt/src/lib/builders/Toggle.svelte.ts
+++ b/packages/melt/src/lib/builders/Toggle.svelte.ts
@@ -62,6 +62,7 @@ export class Toggle {
 		return {
 			[identifiers.trigger]: "",
 			"data-checked": dataAttr(this.value),
+			"aria-pressed": this.value,
 			disabled: disabledAttr(this.disabled),
 			onclick: () => {
 				if (this.disabled) return;


### PR DESCRIPTION
The toggle is missing the `aria-pressed` attribute, so screen readers can't understand their purpose. I also added to the documentation that the `aria-label` attribute is required for toggle buttons to make them accessible to screen readers.


https://github.com/user-attachments/assets/d72456a8-e5e1-4c08-8bd9-db19aec6e77e


https://github.com/user-attachments/assets/25646e96-7723-4eba-8c93-73dda659e814



