### PR TITLE
fix(tooltip): only call useFloating when content open

### DIFF
--- a/.changeset/eighty-tips-retire.md
+++ b/.changeset/eighty-tips-retire.md
@@ -1,0 +1,5 @@
+---
+"melt": patch
+---
+
+tooltip: only call useFloating when content open (fixes #71)

--- a/packages/melt/src/lib/builders/Tooltip.svelte.ts
+++ b/packages/melt/src/lib/builders/Tooltip.svelte.ts
@@ -228,7 +228,7 @@ export class Tooltip {
 			const triggerEl = document.getElementById(this.#ids.trigger);
 			const contentEl = document.getElementById(this.#ids.content);
 
-			if (!triggerEl || !contentEl) return;
+			if (!triggerEl || !contentEl || !this.open) return;
 
 			useFloating(
 				() => triggerEl,
@@ -412,4 +412,3 @@ export class Tooltip {
 		}
 	}
 }
-


### PR DESCRIPTION
fixes #70

Per Floating UI's docs, it looks like `autoUpdate` should only be used when the floating element is open, and that's what was causing this! https://floating-ui.com/docs/autoupdate#usage