### PR TITLE
Fix: Allow options in Select and Combobox to not be DOM-sequential

### DIFF
--- a/.changeset/wild-tigers-nail.md
+++ b/.changeset/wild-tigers-nail.md
@@ -1,0 +1,5 @@
+---
+"melt": patch
+---
+
+allow options in Select and Combobox to not be DOM-sequential

--- a/packages/melt/src/lib/builders/Combobox.svelte.ts
+++ b/packages/melt/src/lib/builders/Combobox.svelte.ts
@@ -282,15 +282,19 @@ export class Combobox<T extends string, Multiple extends boolean = false> extend
 
 	#highlightNext() {
 		const options = this.#getOptionsEls();
-		const current = options.find((o) => o.dataset.value === this.highlighted);
-		const next = current?.nextElementSibling ?? options[0];
+		const next = options.find((_, index, options) => {
+			const current = options.at((index - 1) % options.length);
+			return current?.dataset.value === this.highlighted;
+		});
 		if (isHtmlElement(next)) this.#highlight(next);
 	}
 
 	#highlightPrev() {
 		const options = this.#getOptionsEls();
-		const current = options.find((o) => o.dataset.value === this.highlighted);
-		const prev = current?.previousElementSibling ?? options.at(-1);
+		const prev = options.find((_, index, options) => {
+			const current = options.at((index + 1) % options.length);
+			return current?.dataset.value === this.highlighted;
+		});
 		if (isHtmlElement(prev)) this.#highlight(prev);
 	}
 

--- a/packages/melt/src/lib/builders/Combobox.svelte.ts
+++ b/packages/melt/src/lib/builders/Combobox.svelte.ts
@@ -14,6 +14,7 @@ import { letterRegex } from "$lib/utils/typeahead.svelte";
 import { tick } from "svelte";
 import type { HTMLAttributes, HTMLInputAttributes } from "svelte/elements";
 import { BasePopover, type PopoverProps } from "./Popover.svelte";
+import { findNext, findPrev } from "$lib/utils/array";
 
 const { dataAttrs, dataSelectors, createIds } = createBuilderMetadata("combobox", [
 	"input",
@@ -282,19 +283,13 @@ export class Combobox<T extends string, Multiple extends boolean = false> extend
 
 	#highlightNext() {
 		const options = this.#getOptionsEls();
-		const next = options.find((_, index, options) => {
-			const current = options.at((index - 1) % options.length);
-			return current!.dataset.value === this.highlighted;
-		});
+		const next = findNext(options, (o) => o.dataset.value === this.highlighted);
 		if (isHtmlElement(next)) this.#highlight(next);
 	}
 
 	#highlightPrev() {
 		const options = this.#getOptionsEls();
-		const prev = options.find((_, index, options) => {
-			const current = options.at((index + 1) % options.length);
-			return current!.dataset.value === this.highlighted;
-		});
+		const prev = findPrev(options, (o) => o.dataset.value === this.highlighted);
 		if (isHtmlElement(prev)) this.#highlight(prev);
 	}
 

--- a/packages/melt/src/lib/builders/Combobox.svelte.ts
+++ b/packages/melt/src/lib/builders/Combobox.svelte.ts
@@ -284,7 +284,7 @@ export class Combobox<T extends string, Multiple extends boolean = false> extend
 		const options = this.#getOptionsEls();
 		const next = options.find((_, index, options) => {
 			const current = options.at((index - 1) % options.length);
-			return current?.dataset.value === this.highlighted;
+			return current!.dataset.value === this.highlighted;
 		});
 		if (isHtmlElement(next)) this.#highlight(next);
 	}
@@ -293,7 +293,7 @@ export class Combobox<T extends string, Multiple extends boolean = false> extend
 		const options = this.#getOptionsEls();
 		const prev = options.find((_, index, options) => {
 			const current = options.at((index + 1) % options.length);
-			return current?.dataset.value === this.highlighted;
+			return current!.dataset.value === this.highlighted;
 		});
 		if (isHtmlElement(prev)) this.#highlight(prev);
 	}

--- a/packages/melt/src/lib/builders/Select.svelte.ts
+++ b/packages/melt/src/lib/builders/Select.svelte.ts
@@ -289,15 +289,19 @@ export class Select<T extends string, Multiple extends boolean = false> extends 
 
 	#highlightNext() {
 		const options = this.#getOptionsEls();
-		const current = options.find((o) => o.dataset.value === this.highlighted);
-		const next = current?.nextElementSibling ?? options[0];
+		const next = options.find((_, index, options) => {
+			const current = options.at((index - 1) % options.length);
+			return current?.dataset.value === this.highlighted;
+		});
 		if (isHtmlElement(next)) this.#highlight(next);
 	}
 
 	#highlightPrev() {
 		const options = this.#getOptionsEls();
-		const current = options.find((o) => o.dataset.value === this.highlighted);
-		const prev = current?.previousElementSibling ?? options.at(-1);
+		const prev = options.find((_, index, options) => {
+			const current = options.at((index + 1) % options.length);
+			return current?.dataset.value === this.highlighted;
+		});
 		if (isHtmlElement(prev)) this.#highlight(prev);
 	}
 

--- a/packages/melt/src/lib/builders/Select.svelte.ts
+++ b/packages/melt/src/lib/builders/Select.svelte.ts
@@ -6,9 +6,9 @@ import { isHtmlElement } from "$lib/utils/is";
 import { kbd } from "$lib/utils/keyboard";
 import { pick } from "$lib/utils/object";
 import {
-    SelectionState,
-    type MaybeMultiple,
-    type OnMultipleChange,
+	SelectionState,
+	type MaybeMultiple,
+	type OnMultipleChange,
 } from "$lib/utils/selection-state.svelte";
 import { createTypeahead, letterRegex } from "$lib/utils/typeahead.svelte";
 import { tick } from "svelte";
@@ -288,24 +288,17 @@ export class Select<T extends string, Multiple extends boolean = false> extends 
 		this.highlighted = el.dataset.value as T;
 	}
 
+	#highlightNext() {
+		const options = this.#getOptionsEls();
+		const next = findNext(options, (o) => o.dataset.value === this.highlighted);
+		if (isHtmlElement(next)) this.#highlight(next);
+	}
 
-#highlightNext() {
-  const options = this.#getOptionsEls();
-  const next = findNext(
-    options,
-    (o) => o.dataset.value === this.highlighted
-  );
-  if (isHtmlElement(next)) this.#highlight(next);
-}
-
-#highlightPrev() {
-  const options = this.#getOptionsEls();
-  const prev = findPrev(
-    options,
-    (o) => o.dataset.value === this.highlighted
-  );
-  if (isHtmlElement(prev)) this.#highlight(prev);
-}
+	#highlightPrev() {
+		const options = this.#getOptionsEls();
+		const prev = findPrev(options, (o) => o.dataset.value === this.highlighted);
+		if (isHtmlElement(prev)) this.#highlight(prev);
+	}
 
 	#highlightFirst() {
 		const first = this.#getOptionsEls()[0];

--- a/packages/melt/src/lib/builders/Select.svelte.ts
+++ b/packages/melt/src/lib/builders/Select.svelte.ts
@@ -6,14 +6,15 @@ import { isHtmlElement } from "$lib/utils/is";
 import { kbd } from "$lib/utils/keyboard";
 import { pick } from "$lib/utils/object";
 import {
-	SelectionState,
-	type MaybeMultiple,
-	type OnMultipleChange,
+    SelectionState,
+    type MaybeMultiple,
+    type OnMultipleChange,
 } from "$lib/utils/selection-state.svelte";
 import { createTypeahead, letterRegex } from "$lib/utils/typeahead.svelte";
 import { tick } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
 import { BasePopover, type PopoverProps } from "./Popover.svelte";
+import { findNext, findPrev } from "$lib/utils/array";
 
 const { dataAttrs, dataSelectors, createIds } = createBuilderMetadata("select", [
 	"trigger",
@@ -287,23 +288,24 @@ export class Select<T extends string, Multiple extends boolean = false> extends 
 		this.highlighted = el.dataset.value as T;
 	}
 
-	#highlightNext() {
-		const options = this.#getOptionsEls();
-		const next = options.find((_, index, options) => {
-			const current = options.at((index - 1) % options.length);
-			return current!.dataset.value === this.highlighted;
-		});
-		if (isHtmlElement(next)) this.#highlight(next);
-	}
 
-	#highlightPrev() {
-		const options = this.#getOptionsEls();
-		const prev = options.find((_, index, options) => {
-			const current = options.at((index + 1) % options.length);
-			return current!.dataset.value === this.highlighted;
-		});
-		if (isHtmlElement(prev)) this.#highlight(prev);
-	}
+#highlightNext() {
+  const options = this.#getOptionsEls();
+  const next = findNext(
+    options,
+    (o) => o.dataset.value === this.highlighted
+  );
+  if (isHtmlElement(next)) this.#highlight(next);
+}
+
+#highlightPrev() {
+  const options = this.#getOptionsEls();
+  const prev = findPrev(
+    options,
+    (o) => o.dataset.value === this.highlighted
+  );
+  if (isHtmlElement(prev)) this.#highlight(prev);
+}
 
 	#highlightFirst() {
 		const first = this.#getOptionsEls()[0];

--- a/packages/melt/src/lib/builders/Select.svelte.ts
+++ b/packages/melt/src/lib/builders/Select.svelte.ts
@@ -291,7 +291,7 @@ export class Select<T extends string, Multiple extends boolean = false> extends 
 		const options = this.#getOptionsEls();
 		const next = options.find((_, index, options) => {
 			const current = options.at((index - 1) % options.length);
-			return current?.dataset.value === this.highlighted;
+			return current!.dataset.value === this.highlighted;
 		});
 		if (isHtmlElement(next)) this.#highlight(next);
 	}
@@ -300,7 +300,7 @@ export class Select<T extends string, Multiple extends boolean = false> extends 
 		const options = this.#getOptionsEls();
 		const prev = options.find((_, index, options) => {
 			const current = options.at((index + 1) % options.length);
-			return current?.dataset.value === this.highlighted;
+			return current!.dataset.value === this.highlighted;
 		});
 		if (isHtmlElement(prev)) this.#highlight(prev);
 	}

--- a/packages/melt/src/lib/utils/array.ts
+++ b/packages/melt/src/lib/utils/array.ts
@@ -1,0 +1,23 @@
+export function findNext<T>(array: T[], condition: (item: T) => boolean): T | undefined {
+	const index = array.findIndex(condition);
+
+	if (index === -1) {
+		return undefined; // Condition not met
+	}
+
+	const nextIndex = (index + 1) % array.length; // Wrap around
+
+	return array[nextIndex];
+}
+
+export function findPrev<T>(array: T[], condition: (item: T) => boolean): T | undefined {
+	const index = array.findIndex(condition);
+
+	if (index === -1) {
+		return undefined; // Condition not met
+	}
+
+	const prevIndex = (index - 1 + array.length) % array.length; // Wrap around
+
+	return array[prevIndex];
+}


### PR DESCRIPTION
Previously, options must be sequential in the DOM for keyboard navigation to function as expected.

    <option />
    <option />
    <option />

This change allows options to not be sequential.

    <div>
        <option />
        <option />
    </div>
    <div>
        <option />
    </div>

This facilitates grouping select options or inserting other presentational elements within a Select menu.