### PR TITLE
Allow alternate Select option typeahead strings

### DIFF
--- a/.changeset/spotty-cooks-hear.md
+++ b/.changeset/spotty-cooks-hear.md
@@ -1,0 +1,5 @@
+---
+"melt": minor
+---
+
+select: allow alternate option typeahead strings

--- a/docs/src/api.json
+++ b/docs/src/api.json
@@ -683,7 +683,7 @@
       },
       {
         "name": "getOption",
-        "type": "(\n  value: T,\n  typeahead?: { typeahead: string } | undefined,\n) => {\n  readonly \"data-melt-select-option\": \"\"\n  readonly \"data-value\": DataReturn<T>\n  readonly \"data-typeahead\": string | undefined\n  readonly \"aria-hidden\": true | undefined\n  readonly \"aria-selected\": boolean\n  readonly \"data-highlighted\": \"\" | undefined\n  readonly role: \"option\"\n  readonly onmouseover: () => void\n  readonly onclick: () => void\n}",
+        "type": "(\n  value: T,\n  options?: { typeahead: string } | undefined,\n) => {\n  readonly \"data-melt-select-option\": \"\"\n  readonly \"data-value\": DataReturn<T>\n  readonly \"data-typeahead\": string | undefined\n  readonly \"aria-hidden\": true | undefined\n  readonly \"aria-selected\": boolean\n  readonly \"data-highlighted\": \"\" | undefined\n  readonly role: \"option\"\n  readonly onmouseover: () => void\n  readonly onclick: () => void\n}",
         "description": ""
       }
     ],

--- a/docs/src/api.json
+++ b/docs/src/api.json
@@ -683,7 +683,7 @@
       },
       {
         "name": "getOption",
-        "type": "(value: T) => {\n  readonly \"data-melt-select-option\": \"\"\n  readonly \"data-value\": DataReturn<T>\n  readonly \"aria-hidden\": true | undefined\n  readonly \"aria-selected\": boolean\n  readonly \"data-highlighted\": \"\" | undefined\n  readonly role: \"option\"\n  readonly onmouseover: () => void\n  readonly onclick: () => void\n}",
+        "type": "(\n  value: T,\n  typeahead?: { typeahead: string } | undefined,\n) => {\n  readonly \"data-melt-select-option\": \"\"\n  readonly \"data-value\": DataReturn<T>\n  readonly \"data-typeahead\": string | undefined\n  readonly \"aria-hidden\": true | undefined\n  readonly \"aria-selected\": boolean\n  readonly \"data-highlighted\": \"\" | undefined\n  readonly role: \"option\"\n  readonly onmouseover: () => void\n  readonly onclick: () => void\n}",
         "description": ""
       }
     ],

--- a/packages/melt/src/lib/builders/Select.svelte.ts
+++ b/packages/melt/src/lib/builders/Select.svelte.ts
@@ -259,11 +259,11 @@ export class Select<T extends string, Multiple extends boolean = false> extends 
 		return `${this.ids.content}-option-${dataAttr(value)}`;
 	}
 
-	getOption(value: T, typeahead?: { typeahead: string }) {
+	getOption(value: T, options?: { typeahead: string }) {
 		return {
 			[dataAttrs.option]: "",
 			"data-value": dataAttr(value),
-			"data-typeahead": dataAttr(typeahead?.typeahead),
+			"data-typeahead": dataAttr(options?.typeahead),
 			"aria-hidden": this.open ? undefined : true,
 			"aria-selected": this.#value.has(value),
 			"data-highlighted": dataAttr(this.highlighted === value),

--- a/packages/melt/src/lib/builders/Select.svelte.ts
+++ b/packages/melt/src/lib/builders/Select.svelte.ts
@@ -86,6 +86,7 @@ export class Select<T extends string, Multiple extends boolean = false> extends 
 							...acc,
 							{
 								value: curr.dataset.value as T,
+								typeahead: curr.dataset.typeahead,
 								current: curr.dataset.value === this.highlighted,
 							},
 						];
@@ -258,10 +259,11 @@ export class Select<T extends string, Multiple extends boolean = false> extends 
 		return `${this.ids.content}-option-${dataAttr(value)}`;
 	}
 
-	getOption(value: T) {
+	getOption(value: T, typeahead?: { typeahead: string }) {
 		return {
 			[dataAttrs.option]: "",
 			"data-value": dataAttr(value),
+			"data-typeahead": dataAttr(typeahead?.typeahead),
 			"aria-hidden": this.open ? undefined : true,
 			"aria-selected": this.#value.has(value),
 			"data-highlighted": dataAttr(this.highlighted === value),

--- a/packages/melt/src/lib/utils/typeahead.svelte.ts
+++ b/packages/melt/src/lib/utils/typeahead.svelte.ts
@@ -1,9 +1,8 @@
 import type { MaybeGetter } from "$lib/types";
 import { useDebounce } from "runed";
 import { extract } from "./extract";
-import { isString } from "./is";
 
-type Item = { value: string; current?: boolean };
+type Item = { value: string; typeahead?: string; current?: boolean };
 
 export type CreateTypeaheadArgs<T extends Item> = {
 	/**
@@ -36,7 +35,8 @@ export function createTypeahead<T extends Item>(args: CreateTypeaheadArgs<T>) {
 		const index = items.findIndex((item) => item.current);
 		const itemsForTypeahead = items
 			.filter((item) => {
-				return item.value.toLowerCase().startsWith(value);
+				const searchValue = item.typeahead ?? item.value;
+				return searchValue.toLowerCase().startsWith(value);
 			})
 			.map((item) => ({ item, index: items.indexOf(item) }));
 		if (!itemsForTypeahead.length) return;


### PR DESCRIPTION
Previously, select options' text must always match their value for typeahead to work as expected.

    <option value="A">A</option>
    <option value="B">B</option>
    <option value="C">C</option>

This change allows the value and typeahead text to optionally differ.

    <option value="_1" typeahead="A">A</option>
    <option value="_2" typeahead="B">B</option>
    <option value="C">C</option>

This is useful for multilingual scenarios where the value may be a known constant, but the text rendered on the option may vary from language to language. Allowing alternate typeahead values here prevents having to convert back-and-forth between unlocalized IDs and localized text.

`innerText` was considered, but avoided, since that property may trigger reflows, where changing a dataset entry does not. Further, using a separate value allows typeahead to function even when there is no text element at all (for example, if the "text" is a stylized SVG).