### PR TITLE
added a fallback solution for not having the Crypto API available

### DIFF
--- a/packages/melt/src/lib/builders/Toaster.svelte.ts
+++ b/packages/melt/src/lib/builders/Toaster.svelte.ts
@@ -7,6 +7,7 @@ import { isHtmlElement, isTouch } from "../utils/is";
 import { AnimationFrames } from "$lib/utils/animation-frames.svelte";
 import { safelyHidePopover, safelyShowPopover } from "$lib/utils/popover";
 import { watch } from "runed";
+import { randomUUID } from "$lib/utils/uuid";
 
 const toasterMeta = createBuilderMetadata("toaster", ["root"]);
 
@@ -116,7 +117,7 @@ export class Toaster<T = object> {
 			...props,
 		} satisfies AddToastArgs<T>;
 
-		const id = props.id ?? window.crypto.randomUUID();
+		const id = props.id ?? randomUUID();
 
 		const toast = new Toast({
 			toaster: this,

--- a/packages/melt/src/lib/builders/Tree.svelte.ts
+++ b/packages/melt/src/lib/builders/Tree.svelte.ts
@@ -10,7 +10,7 @@ import { isControlOrMeta } from "$lib/utils/platform";
 import { SelectionState, type MaybeMultiple } from "$lib/utils/selection-state.svelte";
 import { createTypeahead, letterRegex } from "$lib/utils/typeahead.svelte";
 import type { FalseIfUndefined } from "$lib/utils/types";
-
+import { randomUUID } from "$lib/utils/uuid";
 const identifiers = createDataIds("tree", ["root", "item", "group"]);
 
 /**
@@ -124,7 +124,10 @@ export class Tree<I extends TreeItem, Multiple extends boolean = false> {
 	#selected: Selected<Multiple>;
 	#expanded: SelectionState<string, true>;
 
-	#id = crypto.randomUUID();
+
+	#id = randomUUID();
+
+
 
 	/**
 	 * Creates a new Tree instance

--- a/packages/melt/src/lib/utils/uuid.ts
+++ b/packages/melt/src/lib/utils/uuid.ts
@@ -1,0 +1,34 @@
+
+/**
+ * Generates a random UUID v4 string using crypto.randomUUID(), fallbacking to Math.random() if Crypto API is unavailable.
+ * (unsecure browser when using http for example)
+ *
+ * NOTE: The fallback is not cryptographically secure. Use this for non-security-critical
+ * applications or in environments where the Web Crypto API is unavailable.
+ *
+ * @returns {string} A new UUID v4 string.
+ */
+function randomUUID() {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+    return generateUuidV4Math();
+}
+
+
+
+/**
+ * Generates a random UUID v4 string using Math.random().
+ *
+ * NOTE: This is not cryptographically secure. Use this for non-security-critical
+ * applications or in environments where the Web Crypto API is unavailable.
+ *
+ * @returns {string} A new UUID v4 string.
+ */
+function generateUuidV4Math(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+    const r = Math.random() * 16 | 0;
+    const v = c === 'x' ? r : (r & 0x3 | 0x8);
+    return v.toString(16);
+  });
+}


### PR DESCRIPTION
Hi,

i added a new utils function that checks if the browser has the crypto.randomUUID function available,
if not it uses a UUID function that uses the Math.random() function.

for me personal this is relevant since i develop a webinterface for embedded machines that are accessed via http and with absence of internet connection just can´t get a certificat renewal.

without the https the Browser context is considered unsecure and the crypto API is not available

I hope this works out, 
thanks a lot!
BR Tobi
