### PR TITLE
refactor: unblock global type resolution by moving type definition from tsconfig.json

### DIFF
--- a/docs/src/env.d.ts
+++ b/docs/src/env.d.ts
@@ -1,3 +1,2 @@
-// eslint-disable-next-line @typescript-eslint/triple-slash-reference
-/// <reference path="../.astro/types.d.ts" />
-/// <reference types="astro/client" />
+/// <reference types="unplugin-icons/types/astro" />
+/// <reference types="unplugin-icons/types/svelte" />

--- a/docs/tsconfig.json
+++ b/docs/tsconfig.json
@@ -5,8 +5,7 @@
 		"paths": {
 			"@*": ["src/*"]
 		},
-		"lib": ["dom", "dom.iterable", "esnext"],
-		"types": ["unplugin-icons/types/svelte"]
+		"lib": ["dom", "dom.iterable", "esnext"]
 	},
 	"include": ["src/**/*", "tests/**/*"]
 }

--- a/packages/melt/tsconfig.json
+++ b/packages/melt/tsconfig.json
@@ -1,9 +1,6 @@
 {
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
-		// "module": "NodeNext",
-		// "moduleResolution": "NodeNext",
-
 		"lib": ["dom", "dom.iterable", "esnext"],
 		"target": "es2022",
 		"resolveJsonModule": true,
@@ -17,5 +14,5 @@
 		"skipLibCheck": true,
 		"strictNullChecks": true
 	},
-	"include": ["src/**/*", "tests/**/*"]
+	"include": ["src/**/*", "tests/**/*", "*config.ts", "vitest-setup-client.ts"]
 }

--- a/packages/melt/vite.config.ts
+++ b/packages/melt/vite.config.ts
@@ -1,4 +1,3 @@
-// @ts-ignore -- no types for some reason
 import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig } from "vite";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,6 @@
 		"strictNullChecks": true,
 		"stripInternal": true,
 		"ignoreDeprecations": "5.0",
-		"verbatimModuleSyntax": true,
-		"types": ["unplugin-icons/types/astro"]
+		"verbatimModuleSyntax": true
 	}
 }


### PR DESCRIPTION
## Changes

### `packages/melt`
1. Include vite config and setup files to be part of typescript module resolution - fixes type missing error inside

### `docs`
Typescript `types` field is a precise whitelist for packages having type definitions in `./node_modules/@types/*`

1. Moves`unplugin-icons/types/*` definitions,  to allow type definitions in *.d.ts to be exposed to the compiler and IDE toolchain


## Blast radius
1. None