### PR TITLE
fix popover effect when host is not connected to the document

### DIFF
--- a/packages/melt/src/lib/builders/Popover.svelte.ts
+++ b/packages/melt/src/lib/builders/Popover.svelte.ts
@@ -282,11 +282,15 @@ export class BasePopover {
 		const isVisible = $derived(this.open || this.forceVisible);
 		$effect(() => {
 			const el = document.getElementById(this.ids.popover);
+			// Ensure Svelte runes effect is triggered even if 
+			// `el` is not found in the first render.
+			const visible = isVisible;
+			
 			if (!isHtmlElement(el)) {
 				return;
 			}
 
-			if (isVisible) {
+			if (visible) {
 				return autoOpenPopover({ el });
 			} else {
 				safelyHidePopover(el);


### PR DESCRIPTION
In the updated `$effect` callback, if `el` isn't found during the initial render, this `$effect` won't trigger the `isVisible` rune. Even if `el` becomes available later, this effect won't be activated again when `isVisible` changes.

Why isn't `el` found during the first render? In our scenario, `prosemirror-adapter` dynamically mounts the Svelte component into a `div` element that isn't controlled by Svelte. When the Svelte component is mounted, `$effect` will be called, but the host `div` element isn't yet connected to the document, so `document.getElementById()` will return nothing. This issue was first reported in https://github.com/prosekit/prosemirror-adapter/issues/163.

**Minimal reproduction for this issue:**

https://github.com/ocavue/meltui-pm-adapter-modal-issue

Clicking the first button should display the popover content.

**Before:**

https://github.com/user-attachments/assets/283194ef-d1bf-40ae-b526-10fb527acab6

**After:**

https://github.com/user-attachments/assets/300589a1-bbf2-4fad-baec-abe0c947f253